### PR TITLE
Add live character administration endpoint

### DIFF
--- a/Jondo.Unity.Server/Network/ControlApi.cs
+++ b/Jondo.Unity.Server/Network/ControlApi.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.IO;
 using System.Security.Cryptography;
 using System.Text.Json;
+using Jondo.Unity.Protocol;
 
 namespace Jondo.Unity.Launcher.Network
 {
@@ -96,6 +97,10 @@ namespace Jondo.Unity.Launcher.Network
                     case Prefijo + "registro": return ConRol(cuerpo, Roles.Administrador, _ => Registro(cuerpo));
                     case Prefijo + "apagar": return ConRol(cuerpo, Roles.Administrador, _ => Apagar());
                     case Prefijo + "rol": return ConRol(cuerpo, Roles.Administrador, _ => CambiarRol(cuerpo));
+                    case Prefijo + "personaje":
+                        return !metodo.Equals("POST", StringComparison.OrdinalIgnoreCase)
+                            ? Mal(405, "metodo")
+                            : ConRol(cuerpo, Roles.Administrador, _ => AdministrarPersonaje(cuerpo));
 
                     default: return Mal(404, "ruta");
                 }
@@ -147,6 +152,84 @@ namespace Jondo.Unity.Launcher.Network
             bool bien = DatabaseManager.SetAccountRole(quien, rol, out int cuantas);
             if (bien) Console.WriteLine($"[Control] {quien} pasa a {Roles.Nombre(rol)}.");
             return Bien(new { bien, cuantas });
+        }
+
+        /// <summary>
+        /// Cambia las caracteristicas base y los kamas de un personaje conectado, los guarda y
+        /// refresca la ficha sin obligarle a salir ni a reiniciar el servidor.
+        ///
+        /// La ruta pasa por <see cref="ConRol"/> y solo admite administradores. El turno de la
+        /// sesion evita que una orden HTTP pise un movimiento, un combate o cualquier otro paquete
+        /// que el cliente este atendiendo a la vez.
+        /// </summary>
+        private static Respuesta AdministrarPersonaje(string cuerpo)
+        {
+            string nombre = Texto(cuerpo, "personaje");
+            var sesion = SessionRegistry.FindByName(nombre);
+            if (sesion == null || !sesion.HasCharacter || !sesion.IsInWorld)
+                return Mal(404, "personaje-desconectado");
+
+            sesion.UnoCadaVez.Wait();
+            try
+            {
+                using (SessionContext.Push(sesion))
+                {
+                    var estado = sesion.State;
+                    if (estado.IsInFight) return Mal(409, "personaje-en-combate");
+
+                    bool cambio = false;
+                    cambio |= AsignarEntero(cuerpo, "vitalidad", value => estado.StatVitality = value);
+                    cambio |= AsignarEntero(cuerpo, "sabiduria", value => estado.StatWisdom = value);
+                    cambio |= AsignarEntero(cuerpo, "fuerza", value => estado.StatStrength = value);
+                    cambio |= AsignarEntero(cuerpo, "inteligencia", value => estado.StatIntelligence = value);
+                    cambio |= AsignarEntero(cuerpo, "suerte", value => estado.StatChance = value);
+                    cambio |= AsignarEntero(cuerpo, "agilidad", value => estado.StatAgility = value);
+                    if (TryNumero(cuerpo, "kamas", out long kamas))
+                    {
+                        estado.Kamas = Math.Max(0, kamas);
+                        cambio = true;
+                    }
+
+                    if (!cambio) return Mal(400, "sin-cambios");
+
+                    DatabaseManager.SaveCurrentCharacter();
+                    sesion.SendAsync(ConnectionProtocol.Push(Op.Kub,
+                        ConnectionProtocol.BuildCharacteristics())).GetAwaiter().GetResult();
+                    sesion.SendAsync(ConnectionProtocol.Push(Op.Ivf,
+                        ConnectionProtocol.BuildKamas(estado.Kamas))).GetAwaiter().GetResult();
+                    sesion.SendAsync(ConnectionProtocol.Push(Op.Iun,
+                        ConnectionProtocol.BuildPods(0, 1000 + 5L * estado.StatStrength)))
+                        .GetAwaiter().GetResult();
+
+                    Console.WriteLine($"[Control] Personaje {estado.CharacterName}: caracteristicas " +
+                                      $"{estado.StatVitality}/{estado.StatWisdom}/{estado.StatStrength}/" +
+                                      $"{estado.StatIntelligence}/{estado.StatChance}/{estado.StatAgility}, " +
+                                      $"kamas {estado.Kamas}.");
+                    return Bien(new
+                    {
+                        bien = true,
+                        personaje = estado.CharacterName,
+                        vitalidad = estado.StatVitality,
+                        sabiduria = estado.StatWisdom,
+                        fuerza = estado.StatStrength,
+                        inteligencia = estado.StatIntelligence,
+                        suerte = estado.StatChance,
+                        agilidad = estado.StatAgility,
+                        kamas = estado.Kamas,
+                    });
+                }
+            }
+            finally
+            {
+                sesion.UnoCadaVez.Release();
+            }
+        }
+
+        private static bool AsignarEntero(string cuerpo, string campo, Action<int> asignar)
+        {
+            if (!TryNumero(cuerpo, campo, out long valor)) return false;
+            asignar((int)Math.Clamp(valor, 0, int.MaxValue));
+            return true;
         }
 
         // ─── Cada verbo ─────────────────────────────────────────────────────────────────────
@@ -356,6 +439,19 @@ namespace Jondo.Unity.Launcher.Network
                     : 0;
             }
             catch { return 0; }
+        }
+
+        private static bool TryNumero(string json, string campo, out long valor)
+        {
+            valor = 0;
+            try
+            {
+                using var doc = JsonDocument.Parse(json.Length == 0 ? "{}" : json);
+                return doc.RootElement.TryGetProperty(campo, out var v)
+                       && v.ValueKind == JsonValueKind.Number
+                       && v.TryGetInt64(out valor);
+            }
+            catch { return false; }
         }
     }
 }

--- a/docs/README.md
+++ b/docs/README.md
@@ -90,6 +90,12 @@ The exact syntax and behavior of `.item` and `.itemset`, including role checks, 
 data sources, maximum factory effects, persistence, inventory updates and partial-set failures.
 *Go there* when giving an item by template id, creating a complete set or diagnosing a rejected id.
 
+**`live-character-admin.md`** — Live character administration over the local control API.
+The authenticated `POST /api/personaje` route, its administrator-role check, accepted base-stat and
+kamas fields, session serialization, persistence, immediate client refresh and error responses.
+*Go there* when building an administration tool that must update an online character without a
+restart or reconnect.
+
 **`unknown-packets.md`** — What the client sends that no handler claims.
 Why it is grouped by message shape rather than by opcode, the measured field-number ceiling that
 keeps a byte blob from posing as a structure, and the `.packets` command.

--- a/docs/live-character-admin.md
+++ b/docs/live-character-admin.md
@@ -1,0 +1,61 @@
+# Live character administration
+
+The control API can change an online character's base characteristics and kamas without restarting
+the server or making the player reconnect. It is intended for local administration tools that need
+the same immediate feedback as an in-game command.
+
+## Request
+
+Send a `POST` request to `http://127.0.0.1:8888/api/personaje`. The JSON body must carry the token
+of an administrator account (role **5**), the online character name and at least one value to
+change:
+
+```json
+{
+  "token": "<administrator launcher token>",
+  "personaje": "<online character>",
+  "vitalidad": 1000,
+  "sabiduria": 500,
+  "fuerza": 250,
+  "inteligencia": 250,
+  "suerte": 250,
+  "agilidad": 250,
+  "kamas": 50000
+}
+```
+
+Every value after `personaje` is optional. Characteristic values are clamped to the range from zero
+to `Int32.MaxValue`; kamas cannot be negative. The response contains the complete set of resulting
+base values, not only the fields that changed.
+
+The caller is authenticated through the same launcher token and database role check used by the
+other control routes. The HAAPI listener is bound to loopback, and the request log redacts the token.
+The target character must be connected and outside a fight.
+
+## What changes immediately
+
+The server serializes the operation with the target session's normal packet processing, then:
+
+1. changes the in-memory base values;
+2. saves the character through `DatabaseManager.SaveCurrentCharacter()`;
+3. sends refreshed characteristics, kamas and pod capacity to that character.
+
+No client restart, server restart or direct database edit is required.
+
+The endpoint deliberately does not change character level. A level change also has to reconcile
+experience, characteristic capital, spell points, known spell grades and the level-up packet; the
+existing administrator `.level` command owns that complete transition.
+
+## Errors
+
+| HTTP status | Error | Meaning |
+|---|---|---|
+| 400 | `sin-cambios` | No supported numeric field was supplied. |
+| 401 | `sesion` | The launcher token is absent or expired. |
+| 403 | `rol` | The token belongs to an account below administrator. |
+| 404 | `personaje-desconectado` | No connected character matches the supplied name. |
+| 405 | `metodo` | The endpoint was called with a method other than `POST`. |
+| 409 | `personaje-en-combate` | Live base-stat changes are blocked during a fight. |
+
+Implementation: `Jondo.Unity.Server/Network/ControlApi.cs`. Online-character lookup and session
+serialization come from `SessionRegistry` and `GameSession.UnoCadaVez`.


### PR DESCRIPTION
## Summary

- add `POST /api/personaje` for live base-characteristic and kamas updates
- persist changes and immediately refresh characteristics, kamas, and pod capacity in the client
- document the request fields, behavior, and error responses

## Safety

- reuse the existing launcher-token and administrator-role checks
- require the target character to be connected and fully in the world
- serialize the update with the target session and reject changes during fights
- keep level changes on the existing `.level` path, where XP, points, and spells are reconciled together

## Verification

- `dotnet build Jondo.Unity.Server/Jondo.Unity.Server.csproj -c Release -p:SkipRootDeploy=true --no-restore`
- build succeeds with no errors (one pre-existing NU1510 warning)