### PR TITLE
Complete remote server support with a managed relay

### DIFF
--- a/Jondo.Unity.Launcher/Program.cs
+++ b/Jondo.Unity.Launcher/Program.cs
@@ -41,6 +41,25 @@ namespace Jondo.Unity.Launcher
 
             try
             {
+                if (!UI.LauncherPreferences.ServerIsLocal)
+                {
+                    try
+                    {
+                        Network.RemoteRelay.Start(UI.LauncherPreferences.ServerHost);
+                    }
+                    catch (Exception ex)
+                    {
+                        System.Windows.Forms.MessageBox.Show(
+                            UI.LauncherPreferences.Textos.GenericError + "\n\n" + ex.Message,
+                            "Jondo",
+                            System.Windows.Forms.MessageBoxButtons.OK,
+                            System.Windows.Forms.MessageBoxIcon.Error);
+                        return;
+                    }
+                    Console.WriteLine($"[Lanzador] Relé local activo hacia " +
+                                      $"{UI.LauncherPreferences.ServerHost}.");
+                }
+
                 await AsegurarQueHayServidor();
 
                 UI.LauncherWindow.OpenOnDedicatedThread();
@@ -49,6 +68,7 @@ namespace Jondo.Unity.Launcher
             }
             finally
             {
+                Network.RemoteRelay.Stop();
                 Contract.SoltarElSitio();
             }
         }

--- a/Jondo.Unity.Launcher/RemoteRelay.cs
+++ b/Jondo.Unity.Launcher/RemoteRelay.cs
@@ -1,0 +1,142 @@
+using System;
+using System.Collections.Generic;
+using System.Net;
+using System.Net.Sockets;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace Jondo.Unity.Launcher.Network
+{
+    /// <summary>
+    /// Relays the loopback endpoints expected by JondoFix to a server on another machine.
+    ///
+    /// Dofus still talks to 127.0.0.1: that is an invariant of the client mod and keeps the local
+    /// setup unchanged. In remote mode these four listeners bridge those connections to the host
+    /// stored in the launcher preferences. This is ordinary in-process TCP forwarding; it needs
+    /// neither administrator rights nor persistent netsh port-proxy rules.
+    /// </summary>
+    internal static class RemoteRelay
+    {
+        private static readonly int[] Ports = { 5555, 6337, 8888, 15881 };
+        private static readonly object Gate = new object();
+        private static readonly List<TcpListener> Listeners = new List<TcpListener>();
+        private static CancellationTokenSource? _stop;
+        private static string _host = "";
+
+        public static bool IsRunning
+        {
+            get { lock (Gate) return _stop != null; }
+        }
+
+        public static void Start(string host)
+        {
+            if (string.IsNullOrWhiteSpace(host))
+                throw new ArgumentException("A remote server host is required.", nameof(host));
+
+            lock (Gate)
+            {
+                if (_stop != null)
+                {
+                    if (string.Equals(_host, host.Trim(), StringComparison.OrdinalIgnoreCase)) return;
+                    throw new InvalidOperationException("The remote relay is already running for another host.");
+                }
+
+                _host = host.Trim();
+                _stop = new CancellationTokenSource();
+                try
+                {
+                    foreach (int port in Ports)
+                    {
+                        var listener = new TcpListener(IPAddress.Loopback, port);
+                        listener.Start();
+                        Listeners.Add(listener);
+                        _ = AcceptAsync(listener, _host, port, _stop.Token);
+                    }
+                }
+                catch
+                {
+                    StopLocked();
+                    throw;
+                }
+            }
+        }
+
+        public static void Stop()
+        {
+            lock (Gate) StopLocked();
+        }
+
+        private static void StopLocked()
+        {
+            _stop?.Cancel();
+            foreach (var listener in Listeners)
+            {
+                try { listener.Stop(); } catch { }
+            }
+            Listeners.Clear();
+            _stop?.Dispose();
+            _stop = null;
+            _host = "";
+        }
+
+        private static async Task AcceptAsync(TcpListener listener, string host, int port,
+                                              CancellationToken stop)
+        {
+            while (!stop.IsCancellationRequested)
+            {
+                try
+                {
+                    var client = await listener.AcceptTcpClientAsync(stop);
+                    _ = ForwardAsync(client, host, port, stop);
+                }
+                catch (OperationCanceledException) when (stop.IsCancellationRequested)
+                {
+                    break;
+                }
+                catch (ObjectDisposedException) when (stop.IsCancellationRequested)
+                {
+                    break;
+                }
+                catch (Exception ex)
+                {
+                    Program.LogDebug($"Remote relay accept on {port} failed: {ex.Message}");
+                }
+            }
+        }
+
+        private static async Task ForwardAsync(TcpClient local, string host, int port,
+                                               CancellationToken stop)
+        {
+            using (local)
+            using (var remote = new TcpClient())
+            {
+                try
+                {
+                    local.NoDelay = true;
+                    remote.NoDelay = true;
+                    await remote.ConnectAsync(host, port, stop);
+
+                    using NetworkStream fromClient = local.GetStream();
+                    using NetworkStream fromServer = remote.GetStream();
+                    Task upload = fromClient.CopyToAsync(fromServer, stop);
+                    Task download = fromServer.CopyToAsync(fromClient, stop);
+
+                    Task first = await Task.WhenAny(upload, download);
+                    await first;
+                    try
+                    {
+                        if (ReferenceEquals(first, upload)) remote.Client.Shutdown(SocketShutdown.Send);
+                        else local.Client.Shutdown(SocketShutdown.Send);
+                    }
+                    catch { }
+                    await Task.WhenAll(upload, download);
+                }
+                catch (OperationCanceledException) when (stop.IsCancellationRequested) { }
+                catch (Exception ex)
+                {
+                    Program.LogDebug($"Remote relay {host}:{port} failed: {ex.Message}");
+                }
+            }
+        }
+    }
+}

--- a/Jondo.Unity.Launcher/UI/LauncherPreferences.cs
+++ b/Jondo.Unity.Launcher/UI/LauncherPreferences.cs
@@ -14,6 +14,7 @@ namespace Jondo.Unity.Launcher.UI
     ///
     ///   idioma=es|en|fr     el idioma del lanzador, que es también con el que arranca el juego
     ///   cliente=C:\...\Dofus.exe   dónde está el cliente, si no está donde se supone
+    ///   servidor=host-or-ip  el servidor remoto; vacío significa esta misma máquina
     /// </summary>
     internal static class LauncherPreferences
     {

--- a/Jondo.Unity.Server/Network/GameServerProxy.cs
+++ b/Jondo.Unity.Server/Network/GameServerProxy.cs
@@ -34,7 +34,7 @@ namespace Jondo.Unity.Launcher.Network
             _cts = new CancellationTokenSource();
 
             // Igual que en el Zaap: la bandera, después del bind. Si no, IsRunning miente.
-            _tcpListener = new TcpListener(IPAddress.Parse("127.0.0.1"), port);
+            _tcpListener = new TcpListener(ServerBinding.TcpAddress, port);
             _tcpListener.Start();
             _isRunning = true;
 

--- a/Jondo.Unity.Server/Network/HaapiServer.cs
+++ b/Jondo.Unity.Server/Network/HaapiServer.cs
@@ -18,8 +18,15 @@ namespace Jondo.Unity.Launcher.Network
             _isRunning = true;
 
             _listener = new HttpListener();
-            _listener.Prefixes.Add($"http://localhost:{port}/");
-            _listener.Prefixes.Add($"http://127.0.0.1:{port}/");
+            if (ServerBinding.Public)
+            {
+                _listener.Prefixes.Add($"http://+:{port}/");
+            }
+            else
+            {
+                _listener.Prefixes.Add($"http://localhost:{port}/");
+                _listener.Prefixes.Add($"http://127.0.0.1:{port}/");
+            }
             _listener.Start();
 
             Console.WriteLine($"[+] HAAPI HTTP Server listening on port {port}");

--- a/Jondo.Unity.Server/Network/ServerBinding.cs
+++ b/Jondo.Unity.Server/Network/ServerBinding.cs
@@ -6,16 +6,15 @@ namespace Jondo.Unity.Launcher.Network
     /// <summary>
     /// A qué se atan los puertos del emulador: sólo a esta máquina, o a toda la red.
     ///
-    /// De los cuatro que abre el servidor, dos estaban atados a <c>127.0.0.1</c> —el proxy del
-    /// servidor de juego y el zaap— y los otros dos a <c>IPAddress.Any</c>, o sea abiertos a
-    /// cualquiera que compartiera la red: el chat y el nodo de juego. No parece una decisión, sino
-    /// dos ficheros escritos en momentos distintos, porque nada del emulador necesita esos dos
-    /// puertos desde fuera: el cliente de Dofus habla con ellos por <c>localhost</c>, que es adonde
-    /// le manda el mod.
+    /// De los cinco servicios que abre el servidor, el proxy de juego, el zaap y el HAAPI estaban
+    /// atados a <c>127.0.0.1</c>, mientras que el chat y el nodo de juego usaban
+    /// <c>IPAddress.Any</c>. No era una decisión de despliegue: eran listeners escritos en momentos
+    /// distintos. Los cinco siguen cerrados por defecto y se abren juntos cuando se pide el modo
+    /// remoto.
     ///
     /// Así que ahora los cuatro van igual, y para abrirlos hay que pedirlo a propósito con
-    /// <c>JONDO_PUBLIC_BIND=1</c>. Eso hace falta si algún día el servidor vive en otra máquina;
-    /// mientras tanto, cerrado.
+    /// <c>JONDO_PUBLIC_BIND=1</c>. Hace falta cuando el servidor vive en otra máquina; mientras
+    /// tanto, cerrado.
     ///
     /// La idea es de la pull request de Raphaël, que traía un fichero equivalente. El código es
     /// nuestro: aquí sólo hacen falta las dos líneas que de verdad se usan.

--- a/Jondo.Unity.Server/Network/ZaapServer.cs
+++ b/Jondo.Unity.Server/Network/ZaapServer.cs
@@ -161,7 +161,7 @@ namespace Jondo.Unity.Launcher.Network
             // así que si el bind fallaba —el caso normal cuando ya hay otro servidor arriba—
             // IsRunning decía que sí y el semáforo del lanzador pintaba «en línea» con el listener
             // muerto. Con un solo proceso no se notaba porque el fallo mataba el emulador entero.
-            _tcpListener = new TcpListener(IPAddress.Parse("127.0.0.1"), port);
+            _tcpListener = new TcpListener(ServerBinding.TcpAddress, port);
             _tcpListener.Start();
             _isRunning = true;
 

--- a/Jondo.Unity.Server/Program.cs
+++ b/Jondo.Unity.Server/Program.cs
@@ -114,6 +114,12 @@ namespace Jondo.Unity.Launcher
             Console.WriteLine("[+] Starting services...");
             try
             {
+                Console.WriteLine($"[+] Network binding: {ServerBinding.Description}.");
+                if (ServerBinding.Public)
+                {
+                    Console.WriteLine("[!] Public binding does not encrypt traffic. Use it only on " +
+                                      "a trusted network or behind a VPN/tunnel.");
+                }
                 // La llave con la que el lanzador podrá hablarle a este servidor. Una por arranque:
                 // así un lanzador de una sesión anterior no se queda con llave de la de ahora.
                 ControlApi.NuevoSecreto();

--- a/docs/README.md
+++ b/docs/README.md
@@ -76,6 +76,12 @@ and where the independent process and socket limits are enforced.
 *Go there* when changing the team UI, the launch arguments, account-token resolution or the path
 from a launcher row to its game socket.
 
+**`remote-server.md`** — Running the server on another machine.
+How `JONDO_PUBLIC_BIND` opens all server services consistently, how the launcher's managed loopback
+relay bridges JondoFix to the configured host, which ports are involved and what the relay does not
+provide in terms of transport security.
+*Go there* when moving the server to a LAN host or VPS.
+
 **`data.md`** — Where each number comes from.
 The **27** files in `datos/` (22 json, 4 bin and `world.zip`), the **31** tables in
 `bases/world.db`, and which of the **22** Python scripts in `tools/` builds each one. Most come out

--- a/docs/remote-server.md
+++ b/docs/remote-server.md
@@ -1,0 +1,59 @@
+# Remote server and launcher relay
+
+Jondo can run the server on another Windows machine while the launcher and Dofus stay on the
+player's PC. The launcher creates an in-process TCP relay because JondoFix deliberately redirects
+the client's emulator traffic to `127.0.0.1`.
+
+Local installations do not change: every server listener remains loopback-only and the launcher
+starts no relay unless a remote host is configured.
+
+## Server machine
+
+Set `JONDO_PUBLIC_BIND=1` in the environment that starts `Jondo Server.exe`. The existing
+`ServerBinding` switch then applies consistently to all five services instead of only chat and the
+game node:
+
+| Port | Service |
+|---:|---|
+| 5555 | connection and game server |
+| 5556 | game node compatibility listener |
+| 6337 | chat |
+| 8888 | HAAPI and launcher control API |
+| 15881 | Zaap TCP, HTTP and WebSocket |
+
+The named pipe also served by Zaap remains local to the server machine; remote clients use its TCP
+endpoint through the relay.
+
+On Windows, a non-administrator account may need an HTTP URL reservation for the wildcard HAAPI
+listener. The server reports the operating-system error instead of claiming that its services are
+online when the bind fails.
+
+Allow the required ports through the server firewall. Port 5556 is not advertised to the normal
+client and does not need to be exposed unless a separate compatibility setup uses it.
+
+## Player machine
+
+Set the server in `%APPDATA%\Jondo\lanzador.cfg`:
+
+```text
+servidor=server.example.net
+```
+
+An IPv4 address can be used instead of a DNS name. On its next start, the launcher listens only on
+the player's loopback interface on ports 5555, 6337, 8888 and 15881, and forwards each connection
+to the same port on that host. It does not install a Windows service, modify `netsh`, require
+administrator rights or leave forwarding rules behind after it exits.
+
+The launcher itself continues to call the control API directly on the configured host. The relay
+exists for Dofus and JondoFix, whose local-address contract stays unchanged.
+
+## Transport security
+
+The relay is TCP forwarding, not a VPN: it does **not** add encryption or authenticate the remote
+machine. In particular, port 8888 carries launcher login and session data over HTTP. Use the public
+bind only on a trusted LAN or behind an encrypted VPN/tunnel, and restrict the server firewall to
+the expected client addresses. Do not expose these ports indiscriminately to the public internet.
+
+This limitation is explicit because a working remote connection and a secure public deployment are
+different claims. The relay solves address routing; the network owner remains responsible for a
+trusted or encrypted path.


### PR DESCRIPTION
## Summary

- make every server listener honor the existing `JONDO_PUBLIC_BIND` switch
- add a managed loopback relay that connects JondoFix/Dofus to the remote host in launcher preferences
- keep local installs loopback-only and unchanged by default
- document setup, ports, lifecycle, and transport-security limitations

## Why

Remote-host preferences already exist, but GameServerProxy, Zaap, and HAAPI remain loopback-only. Even when those binds are changed, JondoFix intentionally sends Dofus traffic to `127.0.0.1`, so the player machine still needs a bridge. The relay supplies that bridge without administrator rights, Windows services, or persistent `netsh` rules.

## Safety

- public binding remains opt-in
- the relay listens only on the player's loopback interface
- listeners and forwarding tasks stop with the launcher
- startup reports port conflicts instead of silently opening a broken launcher
- documentation and the server log state clearly that TCP forwarding does not add encryption; public deployments still need a trusted LAN, VPN/tunnel, and firewall restrictions

## Verification

- launcher build: 0 warnings, 0 errors
- server build: 0 errors (one pre-existing NU1510 warning)