### PR TITLE
Localize command replies per game session

### DIFF
--- a/Jondo.Unity.Server/Handlers/CommandHandler.cs
+++ b/Jondo.Unity.Server/Handlers/CommandHandler.cs
@@ -42,22 +42,22 @@ namespace Jondo.Unity.Launcher.Handlers
     public static class CommandHandler
     {
         /// <summary>
-        /// Los comandos que existen y cómo se escriben. Manda en dos sitios: decide qué líneas se
-        /// traga el servidor en vez de publicarlas, y es lo que se le contesta al jugador cuando
-        /// se equivoca escribiéndolas.
+        /// Los comandos que existen y la clave de su texto de uso. Manda en dos sitios: decide qué
+        /// líneas se traga el servidor en vez de publicarlas, y lleva al catálogo que contesta al
+        /// jugador en el idioma de su sesión cuando se equivoca escribiéndolas.
         /// </summary>
         private static readonly Dictionary<string, string> Uso =
             new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase)
             {
-                [".kamas"] = "Uso: .kamas <cantidad> — por ejemplo .kamas 10000 (con menos delante, resta)",
-                [".level"] = "Uso: .level <nivel> — por ejemplo .level 200",
-                [".teleport"] = "Uso: .teleport [x,y] — por ejemplo .teleport [-1,0]",
-                [".relative"] = "Uso: .relative — pasa al siguiente MapId de las mismas coordenadas",
-                [".shop"] = "Uso: .shop — sin nada detrás",
-                [".size"] = "Uso: .size <n> — 100 es el tamaño normal, por ejemplo .size 200",
-                [".item"] = "Uso: .item <id> [cantidad] — por ejemplo .item 10784 1",
-                [".itemset"] = "Uso: .itemset <id de panoplia> — por ejemplo .itemset 1",
-                [".packets"] = "Uso: .packets [cuántos] — lo que el cliente manda y no atendemos",
+                [".kamas"] = "usage.kamas",
+                [".level"] = "usage.level",
+                [".teleport"] = "usage.teleport",
+                [".relative"] = "usage.relative",
+                [".shop"] = "usage.shop",
+                [".size"] = "usage.size",
+                [".item"] = "usage.item",
+                [".itemset"] = "usage.itemset",
+                [".packets"] = "usage.packets",
             };
 
         /// <summary>
@@ -106,8 +106,8 @@ namespace Jondo.Unity.Launcher.Handlers
                 // quien escribe "...bueno"— pero la línea sigue su camino normal.
                 if (LooksLikeCommand(command))
                 {
-                    await NotifyAsync(stream, $"El comando {command} no existe. Los que hay: " +
-                                              string.Join(", ", Uso.Keys) + ".", channel, accountId);
+                    await NotifyAsync(stream, T("command.unknown", command,
+                                              string.Join(", ", Uso.Keys)), channel, accountId);
                 }
                 return false;
             }
@@ -128,7 +128,7 @@ namespace Jondo.Unity.Launcher.Handlers
             {
                 Console.WriteLine($"[Comandos] La cuenta {quien} ({Roles.Nombre(rol)}) ha intentado " +
                                   $"{command}, que es de {Roles.Nombre(haceFalta)}. Rechazado.");
-                await NotifyAsync(stream, $"No tienes permiso para usar {command}.", channel, accountId);
+                await NotifyAsync(stream, T("command.denied", command), channel, accountId);
                 return true;   // se lo traga: ni se ejecuta ni se publica en el chat
             }
 
@@ -154,7 +154,7 @@ namespace Jondo.Unity.Launcher.Handlers
             catch (Exception ex)
             {
                 Console.WriteLine($"[Comandos] {command} ha fallado: {ex}");
-                await NotifyAsync(stream, $"El comando {command} ha fallado: {ex.Message}",
+                await NotifyAsync(stream, T("command.failed", command, ex.Message),
                                   channel, accountId);
             }
 
@@ -168,7 +168,7 @@ namespace Jondo.Unity.Launcher.Handlers
             if (!long.TryParse(rest.Trim(), NumberStyles.Integer, CultureInfo.InvariantCulture,
                                out long amount))
             {
-                await NotifyAsync(stream, Uso[".kamas"], channel, accountId);
+                await NotifyAsync(stream, Usage(".kamas"), channel, accountId);
                 return;
             }
 
@@ -186,9 +186,10 @@ namespace Jondo.Unity.Launcher.Handlers
             await NetworkMessage.WriteFrameAsync(stream,
                 ConnectionProtocol.Push(Op.Ivf, ConnectionProtocol.BuildKamas(GameState.Kamas)));
 
-            await NotifyAsync(stream,
-                $"Kamas: {GameState.Kamas} ({(GameState.Kamas - before >= 0 ? "+" : "")}" +
-                $"{GameState.Kamas - before}).", channel, accountId);
+            long difference = GameState.Kamas - before;
+            await NotifyAsync(stream, T("kamas.result", GameState.Kamas,
+                                         difference >= 0 ? "+" : "", difference),
+                              channel, accountId);
 
             Console.WriteLine($"[Comandos] Kamas {before} -> {GameState.Kamas}.");
         }
@@ -216,7 +217,7 @@ namespace Jondo.Unity.Launcher.Handlers
             if (!int.TryParse(rest.Trim(), NumberStyles.Integer, CultureInfo.InvariantCulture,
                               out int wanted))
             {
-                await NotifyAsync(stream, Uso[".level"], channel, accountId);
+                await NotifyAsync(stream, Usage(".level"), channel, accountId);
                 return;
             }
 
@@ -294,15 +295,14 @@ namespace Jondo.Unity.Launcher.Handlers
 
             string spellNote = await RefreshSpellsAsync(stream, before);
 
-            string capped = newLevel != wanted ? $" (se pidió {wanted})" : "";
+            string capped = newLevel != wanted ? T("level.requested", wanted) : "";
             string omega = newLevel > MaxNormalLevel
-                ? " Por encima de 200 no se reparten más puntos de característica."
+                ? T("level.omega")
                 : "";
 
-            await NotifyAsync(stream,
-                $"Nivel {newLevel}{capped}, antes {oldLevel}. Experiencia {GameState.Experience}. " +
-                $"Puntos libres {GameState.CharacterRemainingPoints} de {capital}. {spellNote}{omega}",
-                channel, accountId);
+            await NotifyAsync(stream, T("level.result", newLevel, capped, oldLevel,
+                                         GameState.Experience, GameState.CharacterRemainingPoints,
+                                         capital, spellNote, omega), channel, accountId);
 
             Console.WriteLine($"[Comandos] Nivel {oldLevel} -> {newLevel}, experiencia " +
                               $"{GameState.Experience}, puntos {GameState.CharacterRemainingPoints}.");
@@ -377,13 +377,13 @@ namespace Jondo.Unity.Launcher.Handlers
         {
             if (!SpellTable.IsLoaded)
             {
-                return "Hechizos sin tocar: la tabla de hechizos no está cargada.";
+                return T("spells.table_missing");
             }
 
             var after = Spells(GameState.CharacterLevel);
             if (after.Count == 0)
             {
-                return $"Hechizos sin tocar: la raza {GameState.Breed} no tiene ninguno en los datos.";
+                return T("spells.breed_missing", GameState.Breed);
             }
 
             await NetworkMessage.WriteFrameAsync(stream,
@@ -404,7 +404,7 @@ namespace Jondo.Unity.Launcher.Handlers
                 if (!after.ContainsKey(spell.Key)) closed++;
             }
 
-            return $"Hechizos: {after.Count} (+{opened}, -{closed}, {moved} cambian de grado).";
+            return T("spells.result", after.Count, opened, closed, moved);
         }
 
         // ─── .teleport ──────────────────────────────────────────────────────────
@@ -413,27 +413,27 @@ namespace Jondo.Unity.Launcher.Handlers
         {
             if (!ParseCoordinates(rest, out int x, out int y))
             {
-                await NotifyAsync(stream, Uso[".teleport"], channel, accountId);
+                await NotifyAsync(stream, Usage(".teleport"), channel, accountId);
                 return;
             }
 
             if (GameState.IsInFight)
             {
-                await NotifyAsync(stream, "No se puede teleportar en combate.", channel, accountId);
+                await NotifyAsync(stream, T("teleport.in_fight"), channel, accountId);
                 return;
             }
 
             var match = MapLookup.AtCoordinates(x, y);
             if (match == null)
             {
-                await NotifyAsync(stream, $"No hay ningún mapa en [{x},{y}].", channel, accountId);
+                await NotifyAsync(stream, T("teleport.no_map", x, y), channel, accountId);
                 return;
             }
 
             int cell = await TeleportHandler.ToMapAsync(stream, match.Map.MapId);
             if (cell < 0)
             {
-                await NotifyAsync(stream, $"El mapa {match.Map.MapId} de [{x},{y}] no se puede cargar.",
+                await NotifyAsync(stream, T("teleport.load_failed", match.Map.MapId, x, y),
                                   channel, accountId);
                 return;
             }
@@ -442,13 +442,12 @@ namespace Jondo.Unity.Launcher.Handlers
             // por casas, interiores y mundos aparte, y el jugador tiene que poder saber a cuál de
             // todos ha ido a parar.
             string chosen = match.Candidates > 1
-                ? $" Había {match.Candidates} mapas en esas coordenadas; se ha elegido el de la " +
-                  $"subzona con más casillas andables ({match.SubAreaCells})."
+                ? T("teleport.multiple", match.Candidates, match.SubAreaCells)
                 : "";
 
-            await NotifyAsync(stream,
-                $"En [{x},{y}]: mapa {match.Map.MapId}, {SubAreaName(match.Map.SubAreaId)}, " +
-                $"casilla {cell}.{chosen}", channel, accountId);
+            await NotifyAsync(stream, T("teleport.result", x, y, match.Map.MapId,
+                                         SubAreaName(match.Map.SubAreaId), cell, chosen),
+                              channel, accountId);
         }
 
         // ─── .relative ──────────────────────────────────────────────────────────
@@ -462,12 +461,12 @@ namespace Jondo.Unity.Launcher.Handlers
         {
             if (!string.IsNullOrWhiteSpace(rest))
             {
-                await NotifyAsync(stream, Uso[".relative"], channel, accountId);
+                await NotifyAsync(stream, Usage(".relative"), channel, accountId);
                 return;
             }
             if (GameState.IsInFight)
             {
-                await NotifyAsync(stream, "No se puede teleportar en combate.", channel, accountId);
+                await NotifyAsync(stream, T("teleport.in_fight"), channel, accountId);
                 return;
             }
 
@@ -475,7 +474,7 @@ namespace Jondo.Unity.Launcher.Handlers
             var current = MapManager.GetMapInfo(previousMapId);
             if (current == null)
             {
-                await NotifyAsync(stream, $"El mapa actual {previousMapId} no está en MapPositions.",
+                await NotifyAsync(stream, T("relative.current_missing", previousMapId),
                                   channel, accountId);
                 return;
             }
@@ -483,27 +482,24 @@ namespace Jondo.Unity.Launcher.Handlers
             var relative = MapLookup.NextRelative(previousMapId);
             if (relative == null)
             {
-                await NotifyAsync(stream,
-                    $"No hay otro MapId en [{current.PosX},{current.PosY}].",
-                    channel, accountId);
+                await NotifyAsync(stream, T("relative.none", current.PosX, current.PosY),
+                                  channel, accountId);
                 return;
             }
 
             int cell = await TeleportHandler.ToMapAsync(stream, relative.Map.MapId);
             if (cell < 0)
             {
-                await NotifyAsync(stream,
-                    $"El mapa relativo {relative.Map.MapId} no se puede cargar.",
-                    channel, accountId);
+                await NotifyAsync(stream, T("relative.load_failed", relative.Map.MapId),
+                                  channel, accountId);
                 return;
             }
 
-            string loop = relative.Wrapped ? " Retour au premier MapId." : "";
-            await NotifyAsync(stream,
-                $"Relative [{current.PosX},{current.PosY}] : {previousMapId} -> " +
-                $"{relative.Map.MapId} ({relative.Position}/{relative.Candidates}), " +
-                $"{SubAreaName(relative.Map.SubAreaId)}, casilla {cell}.{loop}",
-                channel, accountId);
+            string loop = relative.Wrapped ? T("relative.wrapped") : "";
+            await NotifyAsync(stream, T("relative.result", current.PosX, current.PosY,
+                                         previousMapId, relative.Map.MapId, relative.Position,
+                                         relative.Candidates, SubAreaName(relative.Map.SubAreaId),
+                                         cell, loop), channel, accountId);
         }
 
         // ─── .shop ──────────────────────────────────────────────────────────────
@@ -518,34 +514,31 @@ namespace Jondo.Unity.Launcher.Handlers
         {
             if (GameState.IsInFight)
             {
-                await NotifyAsync(stream, "No se puede teleportar en combate.", channel, accountId);
+                await NotifyAsync(stream, T("teleport.in_fight"), channel, accountId);
                 return;
             }
 
             var (mapId, npcs) = DatabaseManager.GetMapWithMostNpcSpawns();
             if (mapId <= 0)
             {
-                await NotifyAsync(stream, "No hay ningún NPC colocado en la base: no sé a qué mapa " +
-                                          "llevarte.", channel, accountId);
+                await NotifyAsync(stream, T("shop.no_npcs"), channel, accountId);
                 return;
             }
 
             int cell = await TeleportHandler.ToMapAsync(stream, mapId);
             if (cell < 0)
             {
-                await NotifyAsync(stream, $"El mapa de los vendedores ({mapId}) no está en los datos " +
-                                          "del mundo.", channel, accountId);
+                await NotifyAsync(stream, T("shop.map_missing", mapId), channel, accountId);
                 return;
             }
 
             var info = MapManager.GetMapInfo(mapId);
             string where = info != null
                 ? $"[{info.PosX},{info.PosY}], {SubAreaName(info.SubAreaId)}"
-                : "sitio desconocido";
+                : T("shop.unknown_place");
 
-            await NotifyAsync(stream,
-                $"A la tienda: mapa {mapId} ({where}), {npcs} NPC, casilla {cell}.",
-                channel, accountId);
+            await NotifyAsync(stream, T("shop.result", mapId, where, npcs, cell),
+                              channel, accountId);
         }
 
         // ─── .size ──────────────────────────────────────────────────────────────
@@ -561,7 +554,7 @@ namespace Jondo.Unity.Launcher.Handlers
             if (!int.TryParse(rest.Trim(), NumberStyles.Integer, CultureInfo.InvariantCulture,
                               out int wanted))
             {
-                await NotifyAsync(stream, Uso[".size"], channel, accountId);
+                await NotifyAsync(stream, Usage(".size"), channel, accountId);
                 return;
             }
 
@@ -570,7 +563,7 @@ namespace Jondo.Unity.Launcher.Handlers
             var character = DatabaseManager.GetCharacterById(GameState.CharacterId);
             if (character == null)
             {
-                await NotifyAsync(stream, "No encuentro tu personaje en la base para redibujarlo.",
+                await NotifyAsync(stream, T("size.character_missing"),
                                   channel, accountId);
                 return;
             }
@@ -582,9 +575,9 @@ namespace Jondo.Unity.Launcher.Handlers
                 ConnectionProtocol.Push(Op.Lxc, ConnectionProtocol.BuildLookChanged(character)));
 
             string capped = size != wanted
-                ? $" (se pidió {wanted}; el tope va de {CharacterSize.Minimum} a {CharacterSize.Maximum})"
+                ? T("size.clamped", wanted, CharacterSize.Minimum, CharacterSize.Maximum)
                 : "";
-            await NotifyAsync(stream, $"Tamaño {size} %{capped}. El normal es {CharacterSize.Normal}.",
+            await NotifyAsync(stream, T("size.result", size, capped, CharacterSize.Normal),
                               channel, accountId);
 
             Console.WriteLine($"[Comandos] Tamaño del personaje {GameState.CharacterId}: {size} %.");
@@ -643,7 +636,7 @@ namespace Jondo.Unity.Launcher.Handlers
                 (parts.Length == 2 && !int.TryParse(parts[1], NumberStyles.Integer,
                                                    CultureInfo.InvariantCulture, out _)))
             {
-                await NotifyAsync(stream, Uso[".item"], channel, accountId);
+                await NotifyAsync(stream, Usage(".item"), channel, accountId);
                 return;
             }
 
@@ -653,18 +646,18 @@ namespace Jondo.Unity.Launcher.Handlers
 
             if (quantity <= 0)
             {
-                await NotifyAsync(stream, "La cantidad debe ser mayor que cero.", channel, accountId);
+                await NotifyAsync(stream, T("item.quantity"), channel, accountId);
                 return;
             }
 
             if (!await GiveItemAsync(stream, gid, quantity))
             {
-                await NotifyAsync(stream, $"No existe la plantilla de objeto {gid}.", channel, accountId);
+                await NotifyAsync(stream, T("item.template_missing", gid), channel, accountId);
                 return;
             }
 
             await RefreshPodsAsync(stream);
-            await NotifyAsync(stream, $"Objeto {gid} x{quantity} añadido al inventario.",
+            await NotifyAsync(stream, T("item.added", gid, quantity),
                               channel, accountId);
         }
 
@@ -674,13 +667,13 @@ namespace Jondo.Unity.Launcher.Handlers
             if (!int.TryParse(rest.Trim(), NumberStyles.Integer, CultureInfo.InvariantCulture,
                               out int setId))
             {
-                await NotifyAsync(stream, Uso[".itemset"], channel, accountId);
+                await NotifyAsync(stream, Usage(".itemset"), channel, accountId);
                 return;
             }
 
             if (!ItemSets.TryGetItems(setId, out var templates))
             {
-                await NotifyAsync(stream, $"No existe la panoplia {setId}.", channel, accountId);
+                await NotifyAsync(stream, T("itemset.missing", setId), channel, accountId);
                 return;
             }
 
@@ -695,10 +688,9 @@ namespace Jondo.Unity.Launcher.Handlers
             await RefreshPodsAsync(stream);
             string warning = missing.Count == 0
                 ? ""
-                : $" Plantillas ausentes: {string.Join(", ", missing)}.";
-            await NotifyAsync(stream,
-                $"Panoplia {setId}: {added}/{templates.Count} objetos añadidos.{warning}",
-                channel, accountId);
+                : T("itemset.templates_missing", string.Join(", ", missing));
+            await NotifyAsync(stream, T("itemset.added", setId, added, templates.Count, warning),
+                              channel, accountId);
         }
 
         // ─── .packets ──────────────────────────────────────────────────────────
@@ -722,26 +714,29 @@ namespace Jondo.Unity.Launcher.Handlers
                 (!int.TryParse(rest.Trim(), NumberStyles.Integer, CultureInfo.InvariantCulture,
                                out cuantas) || cuantas <= 0 || cuantas > 40))
             {
-                await NotifyAsync(stream, Uso[".packets"], channel, accountId);
+                await NotifyAsync(stream, Usage(".packets"), channel, accountId);
                 return;
             }
 
             var lista = Network.UnknownPackets.Top(cuantas);
             if (lista.Count == 0)
             {
-                await NotifyAsync(stream, "No hay ningún paquete sin atender apuntado.",
+                await NotifyAsync(stream, T("packets.none"),
                                   channel, accountId);
                 return;
             }
 
-            await NotifyAsync(stream, Network.UnknownPackets.Resumen(), channel, accountId);
+            var counts = Network.UnknownPackets.Counts();
+            await NotifyAsync(stream, T("packets.summary", Network.UnknownPackets.ShapeCount,
+                                         Network.UnknownPackets.OpcodeCount, counts.Unhandled,
+                                         counts.Silenced, counts.Undecodable), channel, accountId);
             foreach (var fila in lista)
             {
                 string marca = fila.Kind switch
                 {
-                    Network.UnknownPackets.Kind.Silenced => "silenciado",
-                    Network.UnknownPackets.Kind.Undecodable => "ilegible",
-                    _ => "sin atender",
+                    Network.UnknownPackets.Kind.Silenced => T("packets.silenced"),
+                    Network.UnknownPackets.Kind.Undecodable => T("packets.undecodable"),
+                    _ => T("packets.unhandled"),
                 };
                 await NotifyAsync(stream,
                     $"{fila.Opcode} x{fila.Occurrences} ({marca}, f{fila.RootField}, " +
@@ -758,6 +753,11 @@ namespace Jondo.Unity.Launcher.Handlers
         }
 
         // ─── Piezas sueltas ─────────────────────────────────────────────────────
+
+        private static string T(string key, params object[] values)
+            => CommandTexts.Get(key, values);
+
+        private static string Usage(string command) => T(Uso[command]);
 
         /// <summary>
         /// El aviso al jugador, por el canal donde escribió para que le salga en la pestaña que
@@ -842,7 +842,7 @@ namespace Jondo.Unity.Launcher.Handlers
         private static string SubAreaName(int subAreaId)
         {
             string name = DatabaseManager.GetSubAreaName(subAreaId);
-            return string.IsNullOrEmpty(name) ? $"subzona {subAreaId}" : name;
+            return string.IsNullOrEmpty(name) ? T("map.subarea", subAreaId) : name;
         }
     }
 }

--- a/Jondo.Unity.Server/Handlers/CommandTexts.cs
+++ b/Jondo.Unity.Server/Handlers/CommandTexts.cs
@@ -1,0 +1,220 @@
+using System;
+using System.Collections.Generic;
+using System.Globalization;
+using System.Text.RegularExpressions;
+using Jondo.Unity.Launcher.Network;
+
+namespace Jondo.Unity.Launcher.Handlers
+{
+    /// <summary>
+    /// Player-facing command replies. The server console stays in its diagnostic language; only
+    /// text sent to the game client is selected from this catalogue.
+    /// </summary>
+    internal static class CommandTexts
+    {
+        private static readonly IReadOnlyDictionary<string, string> Es = new Dictionary<string, string>
+        {
+            ["usage.kamas"] = "Uso: .kamas <cantidad> — por ejemplo .kamas 10000 (con menos delante, resta)",
+            ["usage.level"] = "Uso: .level <nivel> — por ejemplo .level 200",
+            ["usage.teleport"] = "Uso: .teleport [x,y] — por ejemplo .teleport [-1,0]",
+            ["usage.relative"] = "Uso: .relative — pasa al siguiente MapId de las mismas coordenadas",
+            ["usage.shop"] = "Uso: .shop — sin nada detrás",
+            ["usage.size"] = "Uso: .size <n> — 100 es el tamaño normal, por ejemplo .size 200",
+            ["usage.item"] = "Uso: .item <id> [cantidad] — por ejemplo .item 10784 1",
+            ["usage.itemset"] = "Uso: .itemset <id de panoplia> — por ejemplo .itemset 1",
+            ["usage.packets"] = "Uso: .packets [cuántos] — lo que el cliente manda y no atendemos",
+            ["command.unknown"] = "El comando {0} no existe. Los que hay: {1}.",
+            ["command.denied"] = "No tienes permiso para usar {0}.",
+            ["command.failed"] = "El comando {0} ha fallado: {1}",
+            ["kamas.result"] = "Kamas: {0} ({1}{2}).",
+            ["level.requested"] = " (se pidió {0})",
+            ["level.omega"] = " Por encima de 200 no se reparten más puntos de característica.",
+            ["level.result"] = "Nivel {0}{1}, antes {2}. Experiencia {3}. Puntos libres {4} de {5}. {6}{7}",
+            ["spells.table_missing"] = "Hechizos sin tocar: la tabla de hechizos no está cargada.",
+            ["spells.breed_missing"] = "Hechizos sin tocar: la raza {0} no tiene ninguno en los datos.",
+            ["spells.result"] = "Hechizos: {0} (+{1}, -{2}, {3} cambian de grado).",
+            ["teleport.in_fight"] = "No se puede teleportar en combate.",
+            ["teleport.no_map"] = "No hay ningún mapa en [{0},{1}].",
+            ["teleport.load_failed"] = "El mapa {0} de [{1},{2}] no se puede cargar.",
+            ["teleport.multiple"] = " Había {0} mapas en esas coordenadas; se ha elegido el de la subzona con más casillas andables ({1}).",
+            ["teleport.result"] = "En [{0},{1}]: mapa {2}, {3}, casilla {4}.{5}",
+            ["map.subarea"] = "subzona {0}",
+            ["relative.current_missing"] = "El mapa actual {0} no está en MapPositions.",
+            ["relative.none"] = "No hay otro MapId en [{0},{1}].",
+            ["relative.load_failed"] = "El mapa relativo {0} no se puede cargar.",
+            ["relative.wrapped"] = " Vuelta al primer MapId.",
+            ["relative.result"] = "Relative [{0},{1}]: {2} -> {3} ({4}/{5}), {6}, casilla {7}.{8}",
+            ["shop.no_npcs"] = "No hay ningún NPC colocado en la base: no sé a qué mapa llevarte.",
+            ["shop.map_missing"] = "El mapa de los vendedores ({0}) no está en los datos del mundo.",
+            ["shop.unknown_place"] = "sitio desconocido",
+            ["shop.result"] = "A la tienda: mapa {0} ({1}), {2} NPC, casilla {3}.",
+            ["size.character_missing"] = "No encuentro tu personaje en la base para redibujarlo.",
+            ["size.clamped"] = " (se pidió {0}; el tope va de {1} a {2})",
+            ["size.result"] = "Tamaño {0} %{1}. El normal es {2}.",
+            ["item.quantity"] = "La cantidad debe ser mayor que cero.",
+            ["item.template_missing"] = "No existe la plantilla de objeto {0}.",
+            ["item.added"] = "Objeto {0} x{1} añadido al inventario.",
+            ["itemset.missing"] = "No existe la panoplia {0}.",
+            ["itemset.templates_missing"] = " Plantillas ausentes: {0}.",
+            ["itemset.added"] = "Panoplia {0}: {1}/{2} objetos añadidos.{3}",
+            ["packets.none"] = "No hay ningún paquete sin atender apuntado.",
+            ["packets.summary"] = "{0} forma(s) de {1} opcode(s): {2} sin atender, {3} silenciada(s), {4} ilegible(s)",
+            ["packets.silenced"] = "silenciado",
+            ["packets.undecodable"] = "ilegible",
+            ["packets.unhandled"] = "sin atender",
+        };
+
+        private static readonly IReadOnlyDictionary<string, string> En = new Dictionary<string, string>
+        {
+            ["usage.kamas"] = "Usage: .kamas <amount> — for example .kamas 10000 (a negative amount removes kamas)",
+            ["usage.level"] = "Usage: .level <level> — for example .level 200",
+            ["usage.teleport"] = "Usage: .teleport [x,y] — for example .teleport [-1,0]",
+            ["usage.relative"] = "Usage: .relative — move to the next MapId at the same coordinates",
+            ["usage.shop"] = "Usage: .shop — with no argument",
+            ["usage.size"] = "Usage: .size <n> — 100 is the normal size, for example .size 200",
+            ["usage.item"] = "Usage: .item <id> [quantity] — for example .item 10784 1",
+            ["usage.itemset"] = "Usage: .itemset <set id> — for example .itemset 1",
+            ["usage.packets"] = "Usage: .packets [count] — client messages the server does not handle",
+            ["command.unknown"] = "Command {0} does not exist. Available commands: {1}.",
+            ["command.denied"] = "You do not have permission to use {0}.",
+            ["command.failed"] = "Command {0} failed: {1}",
+            ["kamas.result"] = "Kamas: {0} ({1}{2}).",
+            ["level.requested"] = " (requested {0})",
+            ["level.omega"] = " Levels above 200 do not grant characteristic points.",
+            ["level.result"] = "Level {0}{1}, previously {2}. Experience {3}. Free points {4} of {5}. {6}{7}",
+            ["spells.table_missing"] = "Spells unchanged: the spell table is not loaded.",
+            ["spells.breed_missing"] = "Spells unchanged: breed {0} has no spells in the data.",
+            ["spells.result"] = "Spells: {0} (+{1}, -{2}, {3} changed grade).",
+            ["teleport.in_fight"] = "You cannot teleport during a fight.",
+            ["teleport.no_map"] = "There is no map at [{0},{1}].",
+            ["teleport.load_failed"] = "Map {0} at [{1},{2}] cannot be loaded.",
+            ["teleport.multiple"] = " There were {0} maps at those coordinates; the sub-area with the most walkable cells was selected ({1}).",
+            ["teleport.result"] = "At [{0},{1}]: map {2}, {3}, cell {4}.{5}",
+            ["map.subarea"] = "sub-area {0}",
+            ["relative.current_missing"] = "Current map {0} is not in MapPositions.",
+            ["relative.none"] = "There is no other MapId at [{0},{1}].",
+            ["relative.load_failed"] = "Relative map {0} cannot be loaded.",
+            ["relative.wrapped"] = " Back to the first MapId.",
+            ["relative.result"] = "Relative [{0},{1}]: {2} -> {3} ({4}/{5}), {6}, cell {7}.{8}",
+            ["shop.no_npcs"] = "There are no NPC spawns in the database, so there is no shop map to use.",
+            ["shop.map_missing"] = "The vendor map ({0}) is missing from the world data.",
+            ["shop.unknown_place"] = "unknown location",
+            ["shop.result"] = "Shop: map {0} ({1}), {2} NPC, cell {3}.",
+            ["size.character_missing"] = "Your character could not be found in the database for its look refresh.",
+            ["size.clamped"] = " (requested {0}; limits are {1} to {2})",
+            ["size.result"] = "Size {0} %{1}. Normal size is {2}.",
+            ["item.quantity"] = "Quantity must be greater than zero.",
+            ["item.template_missing"] = "Item template {0} does not exist.",
+            ["item.added"] = "Item {0} x{1} added to the inventory.",
+            ["itemset.missing"] = "Item set {0} does not exist.",
+            ["itemset.templates_missing"] = " Missing templates: {0}.",
+            ["itemset.added"] = "Item set {0}: {1}/{2} items added.{3}",
+            ["packets.none"] = "No unhandled packets have been recorded.",
+            ["packets.summary"] = "{0} shape(s) from {1} opcode(s): {2} unhandled, {3} silenced, {4} undecodable",
+            ["packets.silenced"] = "silenced",
+            ["packets.undecodable"] = "undecodable",
+            ["packets.unhandled"] = "unhandled",
+        };
+
+        private static readonly IReadOnlyDictionary<string, string> Fr = new Dictionary<string, string>
+        {
+            ["usage.kamas"] = "Utilisation : .kamas <quantité> — exemple : .kamas 10000 (une valeur négative en retire)",
+            ["usage.level"] = "Utilisation : .level <niveau> — exemple : .level 200",
+            ["usage.teleport"] = "Utilisation : .teleport [x,y] — exemple : .teleport [-1,0]",
+            ["usage.relative"] = "Utilisation : .relative — passe au MapId suivant aux mêmes coordonnées",
+            ["usage.shop"] = "Utilisation : .shop — sans argument",
+            ["usage.size"] = "Utilisation : .size <n> — 100 est la taille normale, exemple : .size 200",
+            ["usage.item"] = "Utilisation : .item <id> [quantité] — exemple : .item 10784 1",
+            ["usage.itemset"] = "Utilisation : .itemset <id de panoplie> — exemple : .itemset 1",
+            ["usage.packets"] = "Utilisation : .packets [nombre] — messages du client non traités",
+            ["command.unknown"] = "La commande {0} n'existe pas. Commandes disponibles : {1}.",
+            ["command.denied"] = "Tu n'as pas la permission d'utiliser {0}.",
+            ["command.failed"] = "La commande {0} a échoué : {1}",
+            ["kamas.result"] = "Kamas : {0} ({1}{2}).",
+            ["level.requested"] = " (niveau demandé : {0})",
+            ["level.omega"] = " Les niveaux supérieurs à 200 ne donnent pas de points de caractéristique.",
+            ["level.result"] = "Niveau {0}{1}, auparavant {2}. Expérience {3}. Points disponibles : {4}/{5}. {6}{7}",
+            ["spells.table_missing"] = "Sorts inchangés : la table des sorts n'est pas chargée.",
+            ["spells.breed_missing"] = "Sorts inchangés : la classe {0} n'en possède aucun dans les données.",
+            ["spells.result"] = "Sorts : {0} (+{1}, -{2}, {3} changent de rang).",
+            ["teleport.in_fight"] = "Téléportation impossible pendant un combat.",
+            ["teleport.no_map"] = "Aucune carte trouvée en [{0},{1}].",
+            ["teleport.load_failed"] = "La carte {0} en [{1},{2}] ne peut pas être chargée.",
+            ["teleport.multiple"] = " {0} cartes existent à ces coordonnées ; celle de la sous-zone avec le plus de cellules praticables a été choisie ({1}).",
+            ["teleport.result"] = "En [{0},{1}] : carte {2}, {3}, cellule {4}.{5}",
+            ["map.subarea"] = "sous-zone {0}",
+            ["relative.current_missing"] = "La carte actuelle {0} est absente de MapPositions.",
+            ["relative.none"] = "Aucun autre MapId en [{0},{1}].",
+            ["relative.load_failed"] = "La carte relative {0} ne peut pas être chargée.",
+            ["relative.wrapped"] = " Retour au premier MapId.",
+            ["relative.result"] = "Relative [{0},{1}] : {2} -> {3} ({4}/{5}), {6}, cellule {7}.{8}",
+            ["shop.no_npcs"] = "Aucun PNJ vendeur n'est enregistré dans la base.",
+            ["shop.map_missing"] = "La carte des vendeurs ({0}) est absente des données du monde.",
+            ["shop.unknown_place"] = "lieu inconnu",
+            ["shop.result"] = "Boutique : carte {0} ({1}), {2} PNJ, cellule {3}.",
+            ["size.character_missing"] = "Ton personnage est introuvable dans la base pour actualiser son apparence.",
+            ["size.clamped"] = " (taille demandée : {0} ; limites : {1} à {2})",
+            ["size.result"] = "Taille : {0} %{1}. Taille normale : {2}.",
+            ["item.quantity"] = "La quantité doit être supérieure à zéro.",
+            ["item.template_missing"] = "Le modèle d'objet {0} n'existe pas.",
+            ["item.added"] = "Objet {0} x{1} ajouté à l'inventaire.",
+            ["itemset.missing"] = "La panoplie {0} n'existe pas.",
+            ["itemset.templates_missing"] = " Modèles absents : {0}.",
+            ["itemset.added"] = "Panoplie {0} : {1}/{2} objets ajoutés.{3}",
+            ["packets.none"] = "Aucun paquet non traité n'a été enregistré.",
+            ["packets.summary"] = "{0} forme(s) pour {1} opcode(s) : {2} non traitée(s), {3} ignorée(s), {4} illisible(s)",
+            ["packets.silenced"] = "ignoré",
+            ["packets.undecodable"] = "illisible",
+            ["packets.unhandled"] = "non traité",
+        };
+
+        static CommandTexts()
+        {
+            AssertSameKeys(En, "en");
+            AssertSameKeys(Fr, "fr");
+        }
+
+        public static string Get(string key, params object[] values)
+            => Get(SessionContext.State.Language, key, values);
+
+        internal static void AssertCatalogs() { }
+
+        internal static string Get(string language, string key, params object[] values)
+        {
+            var catalog = language.Trim().ToLowerInvariant() switch
+            {
+                "en" => En,
+                "fr" => Fr,
+                _ => Es,
+            };
+            if (!catalog.TryGetValue(key, out string? format)) format = Es[key];
+            return values.Length == 0
+                ? format
+                : string.Format(CultureInfo.InvariantCulture, format, values);
+        }
+
+        private static void AssertSameKeys(IReadOnlyDictionary<string, string> catalog, string language)
+        {
+            foreach (string key in Es.Keys)
+            {
+                if (!catalog.ContainsKey(key))
+                    throw new InvalidOperationException($"Command text '{key}' is missing for {language}.");
+                if (!Placeholders(Es[key]).SetEquals(Placeholders(catalog[key])))
+                    throw new InvalidOperationException(
+                        $"Command text '{key}' does not use the same placeholders in {language}.");
+            }
+            if (catalog.Count != Es.Count)
+                throw new InvalidOperationException($"Command text catalogue {language} has unexpected keys.");
+        }
+
+        private static HashSet<int> Placeholders(string format)
+        {
+            var result = new HashSet<int>();
+            foreach (Match match in Regex.Matches(format, @"\{(?<index>\d+)(?:[^}]*)\}"))
+            {
+                result.Add(int.Parse(match.Groups["index"].Value, CultureInfo.InvariantCulture));
+            }
+            return result;
+        }
+    }
+}

--- a/Jondo.Unity.Server/Network/ClientLaunchRegistry.cs
+++ b/Jondo.Unity.Server/Network/ClientLaunchRegistry.cs
@@ -84,7 +84,7 @@ namespace Jondo.Unity.Launcher.Network
                     AccountId = accountId,
                     Hash = hash,
                     LauncherToken = launcherToken ?? "",
-                    Language = string.IsNullOrWhiteSpace(language) ? "fr" : language,
+                    Language = string.IsNullOrWhiteSpace(language) ? "es" : language,
                     Ip = deDonde,
                     CreatedAtUtc = DateTime.UtcNow
                 };

--- a/Jondo.Unity.Server/Network/GameNodeProxy.cs
+++ b/Jondo.Unity.Server/Network/GameNodeProxy.cs
@@ -1041,8 +1041,8 @@ namespace Jondo.Unity.Launcher.Network
         }
 
         /// <summary>
-        /// Redeems the ticket the client presents in kqz and binds the session to an account and
-        /// a server. The ticket travels in field 2 of the message.
+        /// Redeems the ticket the client presents in kqz and binds the session to an account,
+        /// server and language. The ticket travels in field 2 of the message.
         /// </summary>
         private static bool HandleTicketPresentation(byte[] payload, ref long accountId, ref int serverId)
         {
@@ -1061,7 +1061,7 @@ namespace Jondo.Unity.Launcher.Network
 
                 accountId = session.AccountId;
                 serverId = session.ServerId;
-                SessionContext.Current.BindAccount(accountId, serverId);
+                SessionContext.Current.BindAccount(accountId, serverId, session.Language);
                 return true;
             }
             catch (Exception ex)

--- a/Jondo.Unity.Server/Network/GameServerProxy.cs
+++ b/Jondo.Unity.Server/Network/GameServerProxy.cs
@@ -251,7 +251,7 @@ namespace Jondo.Unity.Launcher.Network
                             // The ticket is single-use and binds the next connection to this
                             // account and this server. Without it, the game session would have
                             // no idea who it is serving.
-                            var ticket = SessionRegistry.Issue(accountId, selectedServerId);
+                            var ticket = SessionRegistry.Issue(accountId, selectedServerId, lang);
 
                             byte[] response = ConnectionProtocol.BuildServerSelected(
                                 lang, ticket.Value, "127.0.0.1", Program.gamePort, Program.gamePort);

--- a/Jondo.Unity.Server/Network/GameSession.cs
+++ b/Jondo.Unity.Server/Network/GameSession.cs
@@ -63,11 +63,12 @@ namespace Jondo.Unity.Launcher.Network
                 ? Task.CompletedTask
                 : Jondo.Protocol.NetworkMessage.WriteFrameAsync(Stream, packet);
 
-        public void BindAccount(long accountId, int serverId)
+        public void BindAccount(long accountId, int serverId, string language = "es")
         {
             if (accountId <= 0) throw new ArgumentOutOfRangeException(nameof(accountId));
             AccountId = accountId;
             ServerId = serverId;
+            State.Language = string.IsNullOrWhiteSpace(language) ? "es" : language;
         }
 
         public void EnterWorld()

--- a/Jondo.Unity.Server/Network/SessionRegistry.cs
+++ b/Jondo.Unity.Server/Network/SessionRegistry.cs
@@ -12,9 +12,10 @@ namespace Jondo.Unity.Launcher.Network
     /// Session tickets shared between the connection server and the game server.
     ///
     /// The client makes two separate connections: on the first one it authenticates and picks a
-    /// server, and gets a ticket back; on the second one it presents that ticket to say who it
-    /// is. Without this registry there is no way to know which account the second connection
-    /// belongs to, and the character list would end up being the same one for everybody.
+    /// server, and gets a ticket back; on the second one it presents that ticket to say who it is,
+    /// which server it selected and which language it uses. Without this registry there is no way
+    /// to know which account the second connection belongs to, and the character list would end up
+    /// being the same one for everybody.
     ///
     /// The ticket is single-use and expires, so that it cannot work as a permanent key.
     /// </summary>
@@ -28,6 +29,7 @@ namespace Jondo.Unity.Launcher.Network
             public string Value { get; init; } = "";
             public long AccountId { get; init; }
             public int ServerId { get; init; }
+            public string Language { get; init; } = "es";
             public DateTime Created { get; init; }
         }
 
@@ -176,16 +178,24 @@ namespace Jondo.Unity.Launcher.Network
             return (seVa, llega);
         }
 
-        /// <summary>Creates a new ticket for a specific account and server.</summary>
-        public static Ticket Issue(long accountId, int serverId)
+        /// <summary>Creates a new ticket for a specific account, server and client language.</summary>
+        public static Ticket Issue(long accountId, int serverId, string language = "es")
         {
             Purge();
+
+            string normalized = (language ?? "").Trim().ToLowerInvariant() switch
+            {
+                "en" => "en",
+                "fr" => "fr",
+                _ => "es",
+            };
 
             var ticket = new Ticket
             {
                 Value = Convert.ToHexString(RandomNumberGenerator.GetBytes(16)).ToLowerInvariant(),
                 AccountId = accountId,
                 ServerId = serverId,
+                Language = normalized,
                 Created = DateTime.UtcNow
             };
             _tickets[ticket.Value] = ticket;
@@ -203,6 +213,15 @@ namespace Jondo.Unity.Launcher.Network
             if (!_tickets.TryRemove(value.Trim(), out var ticket)) return null;
             if (DateTime.UtcNow - ticket.Created > Expiration) return null;
             return ticket;
+        }
+
+        /// <summary>Regression guard: the second socket keeps the language chosen on the first.</summary>
+        internal static void AssertLanguageFollowsTicket()
+        {
+            var issued = Issue(1, 1, "fr");
+            var redeemed = Redeem(issued.Value);
+            if (redeemed == null || redeemed.Language != "fr")
+                throw new InvalidOperationException("The session ticket lost the client language.");
         }
 
         private static void Purge()

--- a/Jondo.Unity.Server/Network/UnknownPackets.cs
+++ b/Jondo.Unity.Server/Network/UnknownPackets.cs
@@ -371,6 +371,15 @@ namespace Jondo.Unity.Launcher.Network
         /// <summary>Un resumen de una línea, para el arranque y para el registro.</summary>
         public static string Resumen()
         {
+            var counts = Counts();
+            return $"{ShapeCount} forma(s) de {OpcodeCount} opcode(s): " +
+                   $"{counts.Unhandled} sin atender, {counts.Silenced} silenciada(s), " +
+                   $"{counts.Undecodable} ilegible(s)";
+        }
+
+        /// <summary>Counts by reason, kept separate from the Spanish diagnostic summary.</summary>
+        public static (int Unhandled, int Silenced, int Undecodable) Counts()
+        {
             int sinAtender = 0, silenciados = 0, ilegibles = 0;
             foreach (var r in _rows.Values)
             {
@@ -378,8 +387,7 @@ namespace Jondo.Unity.Launcher.Network
                 else if (r.Kind == Kind.Silenced) silenciados++;
                 else ilegibles++;
             }
-            return $"{ShapeCount} forma(s) de {OpcodeCount} opcode(s): " +
-                   $"{sinAtender} sin atender, {silenciados} silenciada(s), {ilegibles} ilegible(s)";
+            return (sinAtender, silenciados, ilegibles);
         }
 
         /// <summary>

--- a/Jondo.Unity.Server/RegressionGuardTests.cs
+++ b/Jondo.Unity.Server/RegressionGuardTests.cs
@@ -24,6 +24,8 @@ namespace Jondo.Unity.Launcher
             Network.ConnectionProtocolSelfTest.Run();
             Network.ClientLaunchRegistry.AssertTwoClientsAreIsolated();
             Network.ClientLaunchRegistry.AssertEightClientLimit();
+            Network.SessionRegistry.AssertLanguageFollowsTicket();
+            Handlers.CommandTexts.AssertCatalogs();
             AssertPerSessionPlayerCaches();
             AssertSocketWritesAreSerialized();
             AssertProfessionCatalog();

--- a/Jondo.Unity.Server/SessionState.cs
+++ b/Jondo.Unity.Server/SessionState.cs
@@ -12,6 +12,7 @@ namespace Jondo.Unity.Launcher
         public int CharacterLevel { get; set; } = 1;
         public int Breed { get; set; }
         public int Sex { get; set; }
+        public string Language { get; set; } = "es";
         public byte[]? PlayerActorDetails { get; set; }
         public byte[]? LookBytes { get; set; }
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -90,6 +90,11 @@ The exact syntax and behavior of `.item` and `.itemset`, including role checks, 
 data sources, maximum factory effects, persistence, inventory updates and partial-set failures.
 *Go there* when giving an item by template id, creating a complete set or diagnosing a rejected id.
 
+**`command-localization.md`** — Spanish, English and French command replies.
+How the launch language crosses the single-use session ticket, why it belongs to `SessionState`,
+which replies are translated and how catalogue completeness is guarded at startup.
+*Go there* when adding a command response or another server-side player message.
+
 **`unknown-packets.md`** — What the client sends that no handler claims.
 Why it is grouped by message shape rather than by opcode, the measured field-number ceiling that
 keeps a byte blob from posing as a structure, and the `.packets` command.

--- a/docs/command-localization.md
+++ b/docs/command-localization.md
@@ -1,0 +1,43 @@
+# Localized command replies
+
+Administrator chat commands answer in the language selected by the launcher: Spanish, English or
+French. The command words stay the same (`.level`, `.item`, `.teleport`, and so on); usage,
+validation, permission and result messages are localized.
+
+## How the language reaches a game session
+
+The launcher already sends its two-letter language code when it requests a client launch. Dofus
+then presents that language during authentication. The connection server stores the normalized
+code (`es`, `en` or `fr`) in the same single-use ticket that carries the account and server ids.
+
+When the second socket redeems the ticket, `GameSession.BindAccount` copies the language to that
+session's `SessionState`. It is deliberately per-session: two connected accounts can use different
+languages without changing one another or reading desktop preferences on the server machine.
+
+Unknown and empty language codes fall back to Spanish, which preserves the behavior of existing
+clients. The former empty-language fallback to French in `ClientLaunchRegistry` is corrected to
+Spanish as well.
+
+## Catalogue scope
+
+`Jondo.Unity.Server/Handlers/CommandTexts.cs` contains the three catalogues. It covers all
+player-facing replies produced by `CommandHandler`:
+
+- command usage, unknown-command, permission and failure messages;
+- kamas, level, spell and size results;
+- teleport, relative-map and shop results;
+- item and item-set validation and creation;
+- unknown-packet summaries and row labels.
+
+Server-console diagnostics are not translated. They are operational logs rather than text shown to
+a player, and keeping them stable makes searches and support instructions predictable.
+
+## Adding or changing a command
+
+Add every new player-facing format under the same key in the `Es`, `En` and `Fr` dictionaries, then
+call `CommandTexts.Get` through the `T` helper in `CommandHandler`. Keep dynamic values in numbered
+placeholders so each language can reorder the sentence.
+
+The startup regression guard loads the catalogue and rejects a build whose languages have different
+keys or placeholder sets. This turns a missing translation into an explicit startup failure instead
+of silently mixing languages for one command.

--- a/docs/item-commands.md
+++ b/docs/item-commands.md
@@ -6,6 +6,8 @@ administrator-only: because they are deliberately absent from the lower-role per
 
 The command can be written in any chat channel. Jondo consumes the message instead of publishing
 it, then sends the result back as a private informational chat line in the same tab.
+The usage, validation and result text follows the Spanish, English or French language selected for
+that game session; command names and arguments do not change.
 
 ## `.item`
 


### PR DESCRIPTION
## Summary

- carry the launcher/client language through the single-use session ticket
- store language per `GameSession` instead of reading desktop preferences on the server
- localize every player-facing `CommandHandler` reply in Spanish, English, and French
- keep server console diagnostics unchanged
- document the catalogue and extension rules

## Scope

The catalogue covers usage, unknown commands, permissions, failures, kamas, levels, spells, teleport/relative/shop, size, item/itemset, and `.packets` summaries. Command names and arguments remain stable across languages.

## Guards

- unknown or empty language codes fall back to Spanish
- a regression guard checks that all three catalogues have identical keys and placeholder sets
- a ticket regression guard verifies that the selected language survives the connection-to-game socket transition
- the empty launch-language fallback is corrected from French to Spanish

## Verification

- all catalogues contain 48 matching keys
- all translated placeholder sets match
- server build succeeds with 0 errors (one pre-existing NU1510 warning)