### PR TITLE
chore: clean build warnings and dependencies

### DIFF
--- a/Jondo.Unity.Contract/UI/LauncherLogView.cs
+++ b/Jondo.Unity.Contract/UI/LauncherLogView.cs
@@ -59,7 +59,7 @@ namespace Jondo.Unity.Launcher.UI
         }
 
         /// <summary>Cuántas líneas caben de una vez.</summary>
-        private int Visible => Math.Max(1, (Height - Padding.Vertical) / _lineHeight);
+        private int VisibleLineCount => Math.Max(1, (Height - Padding.Vertical) / _lineHeight);
 
         /// <summary>Añade una línea ya troceada por colores.</summary>
         public void Add(params Piece[] pieces)
@@ -101,7 +101,7 @@ namespace Jondo.Unity.Launcher.UI
 
         private void Rescale()
         {
-            int top = Math.Max(0, _lines.Count - Visible);
+            int top = Math.Max(0, _lines.Count - VisibleLineCount);
             _bar.Maximum = top;
             _bar.LargeChange = 1;
             _bar.Enabled = top > 0;

--- a/Jondo.Unity.Deobfuscator/UI/ModelDialog.cs
+++ b/Jondo.Unity.Deobfuscator/UI/ModelDialog.cs
@@ -41,8 +41,9 @@ internal sealed class ModelDialog : Form, IBackgroundWindow
     private readonly Label _hint;
     private readonly Label _verdict;
 
-    private Bitmap? _composed;
-    public Image? ComposedBackground => _composed;
+    // This fixed dialog uses a solid background; transparent child controls therefore have no
+    // composed image to crop, unlike MapperWindow and the launcher.
+    public Image? ComposedBackground => null;
 
     private int E(int pixels) => (int)Math.Round(pixels * _scale);
     private Font Letter(float pixels, FontStyle style = FontStyle.Regular)

--- a/Jondo.Unity.Server/Jondo.Unity.Server.csproj
+++ b/Jondo.Unity.Server/Jondo.Unity.Server.csproj
@@ -44,7 +44,6 @@
          abajo, que es lo que de verdad trae la biblioteca nativa. Cuando salga la 11 estable esto
          se puede quitar y comprobar que NU1903 sigue sin aparecer. -->
     <PackageReference Include="SQLitePCLRaw.bundle_e_sqlite3" Version="2.1.13" />
-    <PackageReference Include="System.Text.Json" Version="10.0.9" />
   </ItemGroup>
 
   <ItemGroup>

--- a/Jondo.Unity.Studio/Jondo.Unity.Studio.csproj
+++ b/Jondo.Unity.Studio/Jondo.Unity.Studio.csproj
@@ -40,10 +40,10 @@
     <PackageReference Include="Avalonia" Version="11.2.3" />
     <PackageReference Include="Avalonia.Desktop" Version="11.2.3" />
     <PackageReference Include="Avalonia.Themes.Fluent" Version="11.2.3" />
-    <!-- Avalonia arrastra Tmds.DBus.Protocol 0.20.0, que lleva GHSA-xrw6-gwf8-vvr9 (gravedad
-         alta). Es la pieza de DBus de Linux y aqui no se usa, pero viaja igual en el paquete, asi
-         que se fija la version corregida. Mismo remedio que con SQLitePCLRaw en el servidor. -->
-    <PackageReference Include="Tmds.DBus.Protocol" Version="0.21.2" />
+    <!-- Avalonia arrastra Tmds.DBus.Protocol 0.20.0, afectado por GHSA-xrw6-gwf8-vvr9. La
+         correccion se retroporto a la rama compatible 0.21 en la version 0.21.3, asi que se fija
+         aqui sin obligar a Studio a saltar a la API 0.92+. -->
+    <PackageReference Include="Tmds.DBus.Protocol" Version="0.21.3" />
   </ItemGroup>
 
   <ItemGroup>

--- a/Jondo.Unity.Tests/Sessions/SessionIsolationTests.cs
+++ b/Jondo.Unity.Tests/Sessions/SessionIsolationTests.cs
@@ -91,15 +91,14 @@ namespace Jondo.Unity.Tests.Sessions
         /// burst of whatever was serving the client.
         /// </remarks>
         [Fact]
-        public void Writes_on_one_socket_are_serialised()
+        public async Task Writes_on_one_socket_are_serialised()
         {
             var stream = new OverlapDetectingStream();
 
-            Task.WhenAll(
+            await Task.WhenAll(
                 Jondo.Protocol.NetworkMessage.WriteRawFrameAsync(stream, new byte[] { 1, 2, 3 }),
                 Jondo.Protocol.NetworkMessage.WriteFrameAsync(stream, new byte[] { 4, 5, 6 }),
-                Jondo.Protocol.NetworkMessage.WriteRawFrameAsync(stream, new byte[] { 7, 8, 9 }))
-                .GetAwaiter().GetResult();
+                Jondo.Protocol.NetworkMessage.WriteRawFrameAsync(stream, new byte[] { 7, 8, 9 }));
 
             Assert.False(stream.OverlapDetected, "packet writes overlapped on one socket");
         }


### PR DESCRIPTION
## Summary

- update `Tmds.DBus.Protocol` to the patched 0.21.3 backport for GHSA-xrw6-gwf8-vvr9
- remove the redundant `System.Text.Json` package reference on .NET 10
- rename the log view's visible-line property to avoid hiding `Control.Visible`
- remove the unused composed-background field from the fixed model dialog
- make the socket serialization test properly asynchronous

## Validation

- `dotnet build Jondo.Unity.sln`: 0 errors, 0 warnings
- `dotnet test Jondo.Unity.Tests\Jondo.Unity.Tests.csproj`: 116/116 passed
- `dotnet list Jondo.Unity.sln package --vulnerable --include-transitive`: no vulnerable packages
