### PR TITLE
Refresh equipment bonuses after moving an item

### DIFF
--- a/Jondo.Unity.Server/Handlers/EquipmentHandler.cs
+++ b/Jondo.Unity.Server/Handlers/EquipmentHandler.cs
@@ -23,10 +23,8 @@ namespace Jondo.Unity.Server.Handlers
     /// En cada hueco cabe una cosa, y eso lo hace cumplir este handler: lo que ya estuviera puesto
     /// sale a la bolsa con su propio ivq antes de que entre lo nuevo.
     ///
-    /// One thing this does NOT do yet is change the characteristics. Equipment adds its bonus in
-    /// field 7 of each entry of kub, and filling that in means knowing which item the uid is,
-    /// which means the inventory coming out of the database instead of out of the capture. Until
-    /// then the item moves and the sheet does not follow.
+    /// Equipment changes also update the session cache used to build the characteristic sheet, so
+    /// bonuses take effect immediately instead of waiting for the next character selection.
     /// </summary>
     public static class EquipmentHandler
     {
@@ -61,6 +59,7 @@ namespace Jondo.Unity.Server.Handlers
             {
                 evicted.Position = Bag;
                 DatabaseManager.SaveItemPosition(evicted.Uid, Bag, SessionContext.State.CharacterId);
+                SessionContext.State.RemoveEquippedItem(evicted.Uid);
 
                 await Jondo.Protocol.NetworkMessage.WriteFrameAsync(stream,
                     ConnectionProtocol.Push(Op.Ivq, Pb.New().Var(1, evicted.Uid).Var(2, Bag).Build()));
@@ -75,6 +74,7 @@ namespace Jondo.Unity.Server.Handlers
             // it is an item we actually hold.
             DatabaseManager.SaveItemPosition(uid, position, SessionContext.State.CharacterId);
             bool known = Managers.Equipment.Move(uid, position);
+            if (known) RefreshCachedBonuses(uid, position);
 
             await Jondo.Protocol.NetworkMessage.WriteFrameAsync(stream,
                 ConnectionProtocol.Push(Op.Ivq, Pb.New().Var(1, uid).Var(2, position).Build()));
@@ -118,6 +118,28 @@ namespace Jondo.Unity.Server.Handlers
             Console.WriteLine($"[Equipment] Item {uid} -> position {position}"
                               + (position == Bag ? " (taken off)." : ".")
                               + (known ? "" : " Not one of ours; the sheet is left alone."));
+        }
+
+        /// <summary>Keeps the characteristic cache aligned with the inventory's item position.</summary>
+        internal static void RefreshCachedBonuses(long uid, int position)
+        {
+            var moved = Managers.Equipment.ByUid(uid);
+            if (moved == null) return;
+
+            if (!Managers.Equipment.IsWorn(position))
+            {
+                SessionContext.State.RemoveEquippedItem(uid);
+                return;
+            }
+
+            var equipped = new EquippedItemInfo { Slot = position };
+            foreach (var effect in moved.Effects)
+            {
+                int value = (int)Math.Clamp(effect.Sheet, int.MinValue, int.MaxValue);
+                equipped.Stats.TryGetValue(effect.Effect, out int previous);
+                equipped.Stats[effect.Effect] = previous + value;
+            }
+            SessionContext.State.SetEquippedItem(uid, equipped);
         }
     }
 }

--- a/Jondo.Unity.Tests/Sessions/EquipmentCacheTests.cs
+++ b/Jondo.Unity.Tests/Sessions/EquipmentCacheTests.cs
@@ -1,0 +1,35 @@
+using Jondo.Unity.Server.Handlers;
+using Jondo.Unity.Server.Managers;
+using Jondo.Unity.Server.Network;
+using Xunit;
+
+namespace Jondo.Unity.Tests.Sessions
+{
+    public class EquipmentCacheTests
+    {
+        [Fact]
+        public void Moving_an_item_updates_and_removes_its_cached_bonuses()
+        {
+            var session = GameSession.SinSocket();
+            using (SessionContext.Push(session))
+            {
+                const long uid = 123456;
+                Equipment.Add(uid, template: 1, quantity: 1, Equipment.Bag,
+                    "[[111,3,0,0],[128,2,0,0]]");
+
+                Assert.True(Equipment.Move(uid, 0));
+                EquipmentHandler.RefreshCachedBonuses(uid, 0);
+
+                var worn = session.State.GetEquippedItemsCopy();
+                Assert.Equal(0, worn[uid].Slot);
+                Assert.Equal(3, worn[uid].Stats[111]);
+                Assert.Equal(2, worn[uid].Stats[128]);
+
+                Assert.True(Equipment.Move(uid, Equipment.Bag));
+                EquipmentHandler.RefreshCachedBonuses(uid, Equipment.Bag);
+
+                Assert.DoesNotContain(uid, session.State.GetEquippedItemsCopy());
+            }
+        }
+    }
+}


### PR DESCRIPTION
## What

- Keep the session equipped-item cache synchronized when EquipmentHandler moves an item.
- Remove evicted or unequipped items from the cache.
- Rebuild cached fixed effects when an item is equipped.
- Add regression coverage for equipment cache updates.

## Why

EquipmentHandler updates the database and Managers.Equipment, then sends a new characteristic sheet. StatsHandler builds that sheet from SessionState''s equipped-item cache, which was left unchanged on this path. The item therefore appeared equipped while AP, MP, and other bonuses stayed stale until character selection or reconnect.

## Tests

dotnet test Jondo.Unity.Tests/Jondo.Unity.Tests.csproj -c Release

343 passed.