### PR TITLE
Persist fatal server startup failures

### DIFF
--- a/Jondo.Unity.Server/Program.cs
+++ b/Jondo.Unity.Server/Program.cs
@@ -36,9 +36,26 @@ namespace Jondo.Unity.Server
                 return;
             }
 
-            try { await ArrancarTodoYEsperar(); }
-            finally { Contract.SoltarElSitio(); }
+            try
+            {
+                await ArrancarTodoYEsperar();
+            }
+            catch (Exception ex)
+            {
+                Environment.ExitCode = 1;
+                string failure = StartupFailure(ex);
+                Console.WriteLine(failure);
+                LogFile.Debug.WriteLine(failure);
+            }
+            finally
+            {
+                Contract.SoltarElSitio();
+            }
         }
+
+        /// <summary>The complete failure written before a WinExe exits during startup.</summary>
+        internal static string StartupFailure(Exception error)
+            => $"[!] Fatal error while starting Jondo Server:{Environment.NewLine}{error}";
 
         private static async Task ArrancarTodoYEsperar()
         {

--- a/Jondo.Unity.Tests/Security/StartupFailureTests.cs
+++ b/Jondo.Unity.Tests/Security/StartupFailureTests.cs
@@ -1,0 +1,20 @@
+using System;
+using Jondo.Unity.Server;
+using Xunit;
+
+namespace Jondo.Unity.Tests.Security
+{
+    public class StartupFailureTests
+    {
+        [Fact]
+        public void Fatal_startup_log_keeps_the_exception_type_and_message()
+        {
+            string log = Program.StartupFailure(
+                new InvalidOperationException("SQLite Error 8: attempt to write a readonly database"));
+
+            Assert.Contains(nameof(InvalidOperationException), log);
+            Assert.Contains("SQLite Error 8", log);
+            Assert.Contains("readonly database", log);
+        }
+    }
+}


### PR DESCRIPTION
## What

- Catch fatal exceptions escaping server initialization.
- Set a non-zero process exit code.
- Write the full exception to both the intercepted console log and debug log.
- Add regression coverage for the preserved exception type and message.

## Why

Jondo Server is a WinExe application. If initialization throws before services start, the process disappears and emulator_console.log ends at the last progress line; the exception is available only in Windows Event Viewer. This was reproduced with a SQLite write error during database initialization.

## Tests

dotnet test Jondo.Unity.Tests/Jondo.Unity.Tests.csproj -c Release

343 passed.