### PR TITLE
Fix character selection immediately after creation

### DIFF
--- a/Jondo.Unity.Server/Handlers/CharacterSelectionHandler.cs
+++ b/Jondo.Unity.Server/Handlers/CharacterSelectionHandler.cs
@@ -208,7 +208,8 @@ namespace Jondo.Unity.Server.Handlers
 
         /// <summary>
         /// Character selection. The id comes in field 1 of the message, inside the wrapper
-        /// (kvw in 3.6.10.10, ksl in older builds).
+        /// (kvw in 3.6.10.10, ksl in older builds). The kvl sent immediately after character
+        /// creation is different: field 1 is the success boolean and field 2 is the character id.
         ///
         /// Returns false if the character does not exist or does not belong to the session's
         /// account. There used to be a default id: when the message carried none, the same
@@ -219,15 +220,7 @@ namespace Jondo.Unity.Server.Handlers
             long characterIdToLoad = 0;
             try
             {
-                byte[]? selection = ConnectionProtocol.ReadPayload(framePayload, Op.Kvw)
-                                    ?? ConnectionProtocol.ReadPayload(framePayload, Op.Ksl)
-                                    ?? ConnectionProtocol.ReadPayload(framePayload, Op.Kvl);
-                if (selection != null && selection.Length > 0)
-                {
-                    var msg = ProtoMessage.Parse(selection);
-                    var charIdField = msg.Fields.FirstOrDefault(f => f.FieldNumber == 1 && f.WireType == 0);
-                    if (charIdField != null) characterIdToLoad = charIdField.VarIntValue;
-                }
+                characterIdToLoad = ReadSelectedCharacterId(framePayload);
             }
             catch (Exception ex)
             {
@@ -372,6 +365,25 @@ namespace Jondo.Unity.Server.Handlers
             }
 
             return true;
+        }
+
+        /// <summary>Reads the two selection layouts without mistaking kvl's success flag for id 1.</summary>
+        internal static long ReadSelectedCharacterId(byte[] framePayload)
+        {
+            byte[]? selection = ConnectionProtocol.ReadPayload(framePayload, Op.Kvw)
+                                ?? ConnectionProtocol.ReadPayload(framePayload, Op.Ksl);
+            int idField = 1;
+
+            if (selection == null)
+            {
+                selection = ConnectionProtocol.ReadPayload(framePayload, Op.Kvl);
+                idField = 2;
+            }
+
+            if (selection == null || selection.Length == 0) return 0;
+            var message = ProtoMessage.Parse(selection);
+            return message.Fields.FirstOrDefault(
+                field => field.FieldNumber == idField && field.WireType == 0)?.VarIntValue ?? 0;
         }
 
         private static byte[] BuildKsqPacket(string characterName, long characterId, int level)

--- a/Jondo.Unity.Tests/Sessions/CharacterSelectionTests.cs
+++ b/Jondo.Unity.Tests/Sessions/CharacterSelectionTests.cs
@@ -1,0 +1,37 @@
+using Jondo.Unity.Protocol;
+using Jondo.Unity.Server.Handlers;
+using Jondo.Unity.Server.Network;
+using Xunit;
+
+namespace Jondo.Unity.Tests.Sessions
+{
+    public class CharacterSelectionTests
+    {
+        [Theory]
+        [InlineData("kvw")]
+        [InlineData("ksl")]
+        public void Normal_selection_reads_the_id_from_field_one(string opcode)
+        {
+            byte[] frame = ConnectionProtocol.Push(opcode, Pb.New().Var(1, 424242).Build());
+
+            Assert.Equal(424242, CharacterSelectionHandler.ReadSelectedCharacterId(frame));
+        }
+
+        [Fact]
+        public void Selection_after_creation_reads_field_two_instead_of_the_success_flag()
+        {
+            byte[] frame = ConnectionProtocol.Push(Op.Kvl,
+                Pb.New().Var(1, 1).Var(2, 987654321).Build());
+
+            Assert.Equal(987654321, CharacterSelectionHandler.ReadSelectedCharacterId(frame));
+        }
+
+        [Fact]
+        public void Missing_character_id_is_rejected()
+        {
+            byte[] frame = ConnectionProtocol.Push(Op.Kvl, Pb.New().Var(1, 1).Build());
+
+            Assert.Equal(0, CharacterSelectionHandler.ReadSelectedCharacterId(frame));
+        }
+    }
+}


### PR DESCRIPTION
## What

- Distinguish the kvl layout used immediately after character creation from normal kvw and ksl messages.
- Read the created character ID from field 2 instead of treating field 1''s success flag as character ID 1.
- Keep the protocol parsing isolated and covered by regression tests.

## Why

Right after creating a character, the client sends kvl with f1 = 1 and f2 = characterId. The current handler reads field 1 for every selection message, then rejects Character 1 as not belonging to the account.

## Tests

dotnet test Jondo.Unity.Tests/Jondo.Unity.Tests.csproj -c Release

346 passed.