### PR TITLE
Add a structured activity journal

### DIFF
--- a/Jondo.Unity.Core/Paths.cs
+++ b/Jondo.Unity.Core/Paths.cs
@@ -363,6 +363,7 @@ namespace Jondo.Unity.Launcher
         // Logs are ALWAYS written inside the logs/ folder to keep the root clean.
         public static string DebugLog => Path.Combine(LogsDir, "emulator_debug.log");
         public static string TrafficLog => Path.Combine(LogsDir, "gameserver_traffic.log");
+        public static string ActivityLog => Path.Combine(LogsDir, "activity.jsonl");
 
         /// <summary>
         /// File that marks which folder is the emulator's data root.

--- a/Jondo.Unity.Server/Diagnostics/ActivityJournal.cs
+++ b/Jondo.Unity.Server/Diagnostics/ActivityJournal.cs
@@ -1,0 +1,67 @@
+using System;
+using System.Text.Json;
+using System.Text.Json.Serialization;
+
+namespace Jondo.Unity.Server
+{
+    /// <summary>
+    /// Append-only activity journal. Each call produces one self-contained JSON line so an
+    /// interrupted write cannot make the rest of the file unreadable.
+    ///
+    /// Callers deliberately choose the detail fields instead of passing request bodies or packet
+    /// payloads. Passwords, launcher tokens and game tickets therefore never reach this log.
+    /// </summary>
+    public sealed class ActivityJournal
+    {
+        private readonly Action<string> _writeLine;
+        private readonly Func<DateTimeOffset> _clock;
+
+        private static readonly JsonSerializerOptions JsonOptions = new JsonSerializerOptions
+        {
+            PropertyNamingPolicy = JsonNamingPolicy.CamelCase,
+            DefaultIgnoreCondition = JsonIgnoreCondition.WhenWritingNull,
+        };
+
+        public static ActivityJournal Current { get; } =
+            new ActivityJournal(LogFile.Activity.WriteLine);
+
+        public ActivityJournal(Action<string> writeLine, Func<DateTimeOffset>? clock = null)
+        {
+            _writeLine = writeLine ?? throw new ArgumentNullException(nameof(writeLine));
+            _clock = clock ?? (() => DateTimeOffset.UtcNow);
+        }
+
+        public void Write(string eventName, long accountId = 0, long characterId = 0,
+                          object? details = null)
+        {
+            if (string.IsNullOrWhiteSpace(eventName)) return;
+
+            try
+            {
+                var entry = new Entry
+                {
+                    Timestamp = _clock().ToUniversalTime(),
+                    Event = eventName.Trim(),
+                    AccountId = accountId > 0 ? accountId : null,
+                    CharacterId = characterId > 0 ? characterId : null,
+                    Details = details,
+                };
+                _writeLine(JsonSerializer.Serialize(entry, JsonOptions));
+            }
+            catch
+            {
+                // Diagnostics must never interrupt gameplay. LogFile also handles I/O failures;
+                // this guard covers a detail object that cannot be serialized.
+            }
+        }
+
+        private sealed class Entry
+        {
+            public DateTimeOffset Timestamp { get; init; }
+            public string Event { get; init; } = "";
+            public long? AccountId { get; init; }
+            public long? CharacterId { get; init; }
+            public object? Details { get; init; }
+        }
+    }
+}

--- a/Jondo.Unity.Server/Diagnostics/LogFile.cs
+++ b/Jondo.Unity.Server/Diagnostics/LogFile.cs
@@ -38,6 +38,9 @@ namespace Jondo.Unity.Server
         /// <summary>El tráfico en crudo, hexadecimal incluido.</summary>
         public static readonly LogFile Traffic = new LogFile(() => Paths.TrafficLog);
 
+        /// <summary>Una línea JSON por acción importante de un jugador o administrador.</summary>
+        public static readonly LogFile Activity = new LogFile(() => Paths.ActivityLog);
+
         /// <summary>
         /// Escribe una línea. Si no se puede escribir —disco lleno, fichero bloqueado— se calla y
         /// no vuelve a intentarlo: un registro que no se puede escribir no es motivo para tirar el

--- a/Jondo.Unity.Server/Handlers/CommandHandler.cs
+++ b/Jondo.Unity.Server/Handlers/CommandHandler.cs
@@ -129,6 +129,8 @@ namespace Jondo.Unity.Server.Handlers
             {
                 Console.WriteLine($"[Comandos] La cuenta {quien} ({Roles.Nombre(rol)}) ha intentado " +
                                   $"{command}, que es de {Roles.Nombre(haceFalta)}. Rechazado.");
+                ActivityJournal.Current.Write("command.denied", quien, GameState.CharacterId,
+                    new { command, role = rol, requiredRole = haceFalta });
                 await NotifyAsync(stream, T("command.denied", command), channel, accountId);
                 return true;   // se lo traga: ni se ejecuta ni se publica en el chat
             }
@@ -136,6 +138,8 @@ namespace Jondo.Unity.Server.Handlers
             string rest = RestOf(text);
             Console.WriteLine($"[Comandos] {command} {rest}".TrimEnd() +
                               $"  (cuenta {quien}, {Roles.Nombre(rol)})");
+            ActivityJournal.Current.Write("command.requested", quien, GameState.CharacterId,
+                new { command, role = rol });
 
             try
             {
@@ -155,6 +159,8 @@ namespace Jondo.Unity.Server.Handlers
             catch (Exception ex)
             {
                 Console.WriteLine($"[Comandos] {command} ha fallado: {ex}");
+                ActivityJournal.Current.Write("command.failed", quien, GameState.CharacterId,
+                    new { command, error = ex.GetType().Name, message = ex.Message });
                 await NotifyAsync(stream, T("command.failed", command, ex.Message),
                                   channel, accountId);
             }
@@ -658,6 +664,10 @@ namespace Jondo.Unity.Server.Handlers
             }
 
             await RefreshPodsAsync(stream);
+            ActivityJournal.Current.Write("item.granted",
+                accountId > 0 ? accountId : SessionContext.Current.AccountId,
+                GameState.CharacterId,
+                new { source = "command", gid, quantity });
             await NotifyAsync(stream, T("item.added", gid, quantity),
                               channel, accountId);
         }
@@ -690,6 +700,10 @@ namespace Jondo.Unity.Server.Handlers
             string warning = missing.Count == 0
                 ? ""
                 : T("itemset.templates_missing", string.Join(", ", missing));
+            ActivityJournal.Current.Write("itemset.granted",
+                accountId > 0 ? accountId : SessionContext.Current.AccountId,
+                GameState.CharacterId,
+                new { source = "command", setId, added, requested = templates.Count, missing });
             await NotifyAsync(stream, T("itemset.added", setId, added, templates.Count, warning),
                               channel, accountId);
         }

--- a/Jondo.Unity.Server/Handlers/EquipmentHandler.cs
+++ b/Jondo.Unity.Server/Handlers/EquipmentHandler.cs
@@ -57,8 +57,10 @@ namespace Jondo.Unity.Server.Handlers
             // nuevo, y se le manda su propio ivq: sin eso las dos cosas se quedaban en el mismo
             // hueco a la vez y el aspecto lo decidía la primera que se encontrase, no la que el
             // jugador acababa de ponerse.
+            var evictedUids = new System.Collections.Generic.List<long>();
             foreach (var evicted in Managers.Equipment.Occupants(position, uid))
             {
+                evictedUids.Add(evicted.Uid);
                 evicted.Position = Bag;
                 DatabaseManager.SaveItemPosition(evicted.Uid, Bag, SessionContext.State.CharacterId);
 
@@ -118,6 +120,10 @@ namespace Jondo.Unity.Server.Handlers
             Console.WriteLine($"[Equipment] Item {uid} -> position {position}"
                               + (position == Bag ? " (taken off)." : ".")
                               + (known ? "" : " Not one of ours; the sheet is left alone."));
+            ActivityJournal.Current.Write("equipment.moved",
+                accountId > 0 ? accountId : SessionContext.Current.AccountId,
+                SessionContext.State.CharacterId,
+                new { uid, position, known, evicted = evictedUids });
         }
     }
 }

--- a/Jondo.Unity.Server/Handlers/FightHandler.cs
+++ b/Jondo.Unity.Server/Handlers/FightHandler.cs
@@ -1488,6 +1488,14 @@ namespace Jondo.Unity.Server.Handlers
 
             var character = DatabaseManager.GetCharacterById(GameState.CharacterId);
             long me = GameState.CharacterId;
+            ActivityJournal.Current.Write("fight.started", SessionContext.Current.AccountId, me,
+                new
+                {
+                    fightId = fight.FightId,
+                    mapId = fight.MapId,
+                    roleplayMapId = fight.RoleplayMapId,
+                    monsters = fight.Team1.Count,
+                });
 
             // Los retos que quedaran sin validar los cierra el servidor aquí, ANTES del kai: si el
             // jugador se declaró listo con uno marcado y sin validar, ése cuenta, y si ni eso, el
@@ -3882,6 +3890,18 @@ namespace Jondo.Unity.Server.Handlers
             }
 
             int duration = (int)Math.Max(0, (DateTime.UtcNow - fight.StartedAt).TotalMilliseconds);
+            ActivityJournal.Current.Write("fight.ended", SessionContext.Current.AccountId,
+                GameState.CharacterId,
+                new
+                {
+                    fightId = fight.FightId,
+                    won,
+                    durationMs = duration,
+                    xp = xpGained,
+                    kamas,
+                    itemKinds = loot.Count,
+                    itemQuantity = loot.Sum(item => item.Value),
+                });
 
             await WriteFrameAsync(stream, ConnectionProtocol.Push(Op.Kuf,
                 Network.FightProtocol.BuildFightOver()));

--- a/Jondo.Unity.Server/Handlers/LotteryHandler.cs
+++ b/Jondo.Unity.Server/Handlers/LotteryHandler.cs
@@ -43,8 +43,17 @@ namespace Jondo.Unity.Server.Handlers
             if (prize == null)
             {
                 Console.WriteLine("[Lotería] La tirada no ha dado nada.");
+                ActivityJournal.Current.Write("lottery.empty",
+                    Jondo.Unity.Server.Network.SessionContext.Current.AccountId,
+                    Jondo.Unity.Server.Network.SessionContext.State.CharacterId,
+                    new { elementId, skillId });
                 return;
             }
+
+            ActivityJournal.Current.Write("lottery.prize",
+                Jondo.Unity.Server.Network.SessionContext.Current.AccountId,
+                Jondo.Unity.Server.Network.SessionContext.State.CharacterId,
+                new { elementId, skillId, uid = prize.Uid, gid = prize.Gid, quantity = prize.Quantity });
 
             // Lo que la máquina contesta, con la forma de la captura.
             await Jondo.Protocol.NetworkMessage.WriteFrameAsync(stream,

--- a/Jondo.Unity.Server/Network/ControlApi.cs
+++ b/Jondo.Unity.Server/Network/ControlApi.cs
@@ -96,12 +96,14 @@ namespace Jondo.Unity.Server.Network
                     // en el servidor, cada vez. Que el lanzador enseñe o no el botón es cosmético:
                     // el lanzador está en el ordenador del jugador y ahí no se confía en nada.
                     case Prefijo + "registro": return ConRol(cuerpo, Roles.Administrador, _ => Registro(cuerpo));
-                    case Prefijo + "apagar": return ConRol(cuerpo, Roles.Administrador, _ => Apagar());
-                    case Prefijo + "rol": return ConRol(cuerpo, Roles.Administrador, _ => CambiarRol(cuerpo));
+                    case Prefijo + "apagar": return ConRol(cuerpo, Roles.Administrador, Apagar);
+                    case Prefijo + "rol": return ConRol(cuerpo, Roles.Administrador,
+                        cuenta => CambiarRol(cuerpo, cuenta));
                     case Prefijo + "personaje":
                         return !metodo.Equals("POST", StringComparison.OrdinalIgnoreCase)
                             ? Mal(405, "metodo")
-                            : ConRol(cuerpo, Roles.Administrador, _ => AdministrarPersonaje(cuerpo));
+                            : ConRol(cuerpo, Roles.Administrador,
+                                cuenta => AdministrarPersonaje(cuerpo, cuenta));
 
                     default: return Mal(404, "ruta");
                 }
@@ -140,18 +142,22 @@ namespace Jondo.Unity.Server.Network
             {
                 Console.WriteLine($"[Control] La cuenta {cuenta} ({Roles.Nombre(rol)}) ha intentado algo " +
                                   $"de {Roles.Nombre(haceFalta)}. Rechazado.");
+                ActivityJournal.Current.Write("admin.denied", cuenta,
+                    details: new { role = rol, requiredRole = haceFalta });
                 return Mal(403, "rol");
             }
             return hacer(cuenta);
         }
 
         /// <summary>Sube o baja el rol de una cuenta. Sólo un administrador llega aquí.</summary>
-        private static Respuesta CambiarRol(string cuerpo)
+        private static Respuesta CambiarRol(string cuerpo, long administrador)
         {
             string quien = Texto(cuerpo, "cuenta");
             int rol = (int)Numero(cuerpo, "rol");
             bool bien = DatabaseManager.SetAccountRole(quien, rol, out int cuantas);
             if (bien) Console.WriteLine($"[Control] {quien} pasa a {Roles.Nombre(rol)}.");
+            ActivityJournal.Current.Write("admin.role.changed", administrador,
+                details: new { account = quien, requestedRole = rol, changed = bien, rows = cuantas });
             return Bien(new { bien, cuantas });
         }
 
@@ -163,7 +169,7 @@ namespace Jondo.Unity.Server.Network
         /// sesion evita que una orden HTTP pise un movimiento, un combate o cualquier otro paquete
         /// que el cliente este atendiendo a la vez.
         /// </summary>
-        private static Respuesta AdministrarPersonaje(string cuerpo)
+        private static Respuesta AdministrarPersonaje(string cuerpo, long administrador)
         {
             string nombre = Texto(cuerpo, "personaje");
             var sesion = SessionRegistry.FindByName(nombre);
@@ -211,6 +217,19 @@ namespace Jondo.Unity.Server.Network
                                       $"{estado.StatVitality}/{estado.StatWisdom}/{estado.StatStrength}/" +
                                       $"{estado.StatIntelligence}/{estado.StatChance}/{estado.StatAgility}, " +
                                       $"kamas {estado.Kamas}.");
+                    ActivityJournal.Current.Write("admin.character.updated", administrador,
+                        estado.CharacterId,
+                        new
+                        {
+                            character = estado.CharacterName,
+                            vitality = estado.StatVitality,
+                            wisdom = estado.StatWisdom,
+                            strength = estado.StatStrength,
+                            intelligence = estado.StatIntelligence,
+                            chance = estado.StatChance,
+                            agility = estado.StatAgility,
+                            kamas = estado.Kamas,
+                        });
                     return Bien(new
                     {
                         bien = true,
@@ -424,9 +443,10 @@ namespace Jondo.Unity.Server.Network
         /// el apagado por fallido justo cuando había funcionado. Medido: la petición volvía con el
         /// cuerpo vacío.
         /// </summary>
-        private static Respuesta Apagar()
+        private static Respuesta Apagar(long administrador)
         {
             Console.WriteLine("[Control] El lanzador pide apagar el servidor.");
+            ActivityJournal.Current.Write("admin.server.shutdown", administrador);
             _ = System.Threading.Tasks.Task.Run(async () =>
             {
                 await System.Threading.Tasks.Task.Delay(300);

--- a/Jondo.Unity.Server/Network/UnknownPackets.cs
+++ b/Jondo.Unity.Server/Network/UnknownPackets.cs
@@ -132,7 +132,22 @@ namespace Jondo.Unity.Server.Network
                 // estos puede llegar cien veces por minuto —el ping del cliente sin ir más lejos—
                 // y abrir SQLite en cada uno pondría el disco a trabajar para no aprender nada
                 // nuevo. Lo que interesa es que la forma EXISTA en la lista, no el número exacto.
-                if (cuantas == 1 || cuantas % 100 == 0) Guardar(fila);
+                if (cuantas == 1 || cuantas % 100 == 0)
+                {
+                    Guardar(fila);
+                    ActivityJournal.Current.Write("packet.unknown", SeguroLaCuenta(),
+                        SeguroElPersonaje(),
+                        new
+                        {
+                            opcode = fila.Opcode,
+                            rootField = fila.RootField,
+                            kind = fila.Kind.ToString(),
+                            signature = fila.Signature,
+                            occurrences = cuantas,
+                            mapId = fila.MapId,
+                            payloadBytes = fila.PayloadBytes,
+                        });
+                }
             }
             catch
             {
@@ -196,6 +211,18 @@ namespace Jondo.Unity.Server.Network
         private static long SeguroElMapa()
         {
             try { return SessionContext.State.MapId; }
+            catch { return 0; }
+        }
+
+        private static long SeguroLaCuenta()
+        {
+            try { return SessionContext.Current.AccountId; }
+            catch { return 0; }
+        }
+
+        private static long SeguroElPersonaje()
+        {
+            try { return SessionContext.State.CharacterId; }
             catch { return 0; }
         }
 

--- a/Jondo.Unity.Tests/Diagnostics/ActivityJournalTests.cs
+++ b/Jondo.Unity.Tests/Diagnostics/ActivityJournalTests.cs
@@ -1,0 +1,67 @@
+using System;
+using System.Collections.Generic;
+using System.Text.Json;
+using Jondo.Unity.Server;
+using Xunit;
+
+namespace Jondo.Unity.Tests.Diagnostics
+{
+    public class ActivityJournalTests
+    {
+        [Fact]
+        public void One_action_is_one_complete_json_line()
+        {
+            var lines = new List<string>();
+            var instant = new DateTimeOffset(2026, 8, 27, 14, 30, 0, TimeSpan.FromHours(2));
+            var journal = new ActivityJournal(lines.Add, () => instant);
+
+            journal.Write("equipment.moved", 42, 84,
+                new { uid = 1234, position = 12, known = true });
+
+            string line = Assert.Single(lines);
+            using var json = JsonDocument.Parse(line);
+            var root = json.RootElement;
+            Assert.Equal("2026-08-27T12:30:00+00:00", root.GetProperty("timestamp").GetString());
+            Assert.Equal("equipment.moved", root.GetProperty("event").GetString());
+            Assert.Equal(42, root.GetProperty("accountId").GetInt64());
+            Assert.Equal(84, root.GetProperty("characterId").GetInt64());
+            Assert.Equal(1234, root.GetProperty("details").GetProperty("uid").GetInt64());
+            Assert.Equal(12, root.GetProperty("details").GetProperty("position").GetInt32());
+            Assert.True(root.GetProperty("details").GetProperty("known").GetBoolean());
+        }
+
+        [Fact]
+        public void Unknown_identities_are_omitted_instead_of_written_as_zero()
+        {
+            var lines = new List<string>();
+            var journal = new ActivityJournal(lines.Add);
+
+            journal.Write("server.started");
+
+            using var json = JsonDocument.Parse(Assert.Single(lines));
+            Assert.False(json.RootElement.TryGetProperty("accountId", out _));
+            Assert.False(json.RootElement.TryGetProperty("characterId", out _));
+            Assert.False(json.RootElement.TryGetProperty("details", out _));
+        }
+
+        [Fact]
+        public void Invalid_events_and_unserializable_details_cannot_break_gameplay()
+        {
+            var lines = new List<string>();
+            var journal = new ActivityJournal(lines.Add);
+            var cycle = new CyclicDetail();
+            cycle.Self = cycle;
+
+            journal.Write("   ");
+            Exception? error = Record.Exception(() => journal.Write("broken.detail", details: cycle));
+
+            Assert.Null(error);
+            Assert.Empty(lines);
+        }
+
+        private sealed class CyclicDetail
+        {
+            public CyclicDetail? Self { get; set; }
+        }
+    }
+}

--- a/README.md
+++ b/README.md
@@ -65,6 +65,11 @@ Jondo.Unity.*/                source code
 
 `content/` **is** in the repository, deliberately: it is the only folder a person edits by hand, it is small, and a change in it is a reviewable diff.
 
+Important player and administrator actions are also written as one JSON object per line in
+`logs/activity.jsonl`. Commands, equipment moves, lottery prizes, granted items, fights, live
+administration and new unhandled packet shapes can therefore be filtered without scraping the
+human-readable console log. Credentials, launcher tokens and game tickets are never included.
+
 Not in the repository because they are not needed to play: `bases/` (built on first run), `logs/`, `tools/` (the Python that regenerates `datos/`) and `dofus3_data/` (436 MB of raw client dump, only used by those tools).
 
 ---


### PR DESCRIPTION
## Summary
- add an append-only JSON Lines journal at logs/activity.jsonl
- record command requests, denials and failures; item and item-set grants; lottery results; equipment changes; fight starts and results; live-admin changes; and sampled unknown packets
- include stable timestamps, action/outcome fields and optional account, character, fight, map and item identifiers
- keep secrets, packet payloads and HTTP bodies out of the journal
- isolate journal write failures so gameplay is never interrupted
- document the format, event catalogue and retention expectations

## Validation
- 345 tests passed, 0 failed
- new tests cover stable serialization, omission of unavailable identifiers, and write-failure isolation