### PR TITLE
Run build and tests on pull requests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,47 @@
+name: CI
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+permissions:
+  contents: read
+
+concurrency:
+  group: ci-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  build-and-test:
+    runs-on: windows-latest
+    timeout-minutes: 20
+
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v4
+
+      - name: Install .NET 10
+        uses: actions/setup-dotnet@v4
+        with:
+          dotnet-version: 10.0.x
+          cache: true
+          cache-dependency-path: '**/*.csproj'
+
+      - name: Restore
+        run: dotnet restore Jondo.Unity.sln
+
+      - name: Build
+        run: dotnet build Jondo.Unity.sln --configuration Release --no-restore
+
+      - name: Test
+        run: dotnet test Jondo.Unity.Tests/Jondo.Unity.Tests.csproj --configuration Release --no-build --logger "trx;LogFileName=tests.trx" --results-directory TestResults
+
+      - name: Upload test results
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: test-results
+          path: TestResults/*.trx
+          if-no-files-found: ignore

--- a/.gitignore
+++ b/.gitignore
@@ -89,6 +89,7 @@ datos/cytrus/
 clientes/
 
 # El proyecto de tests compila como cualquier otro
+TestResults/
 Jondo.Unity.Tests/bin/
 Jondo.Unity.Tests/obj/
 Jondo.Unity.Studio/bin/


### PR DESCRIPTION
## Summary
- run the full solution restore and Release build on pushes to main and pull requests
- run the xUnit project and upload its TRX result as an artifact
- use .NET 10 package caching, read-only contents permissions, concurrency cancellation, and a 20-minute timeout
- keep local TestResults output out of version control

## Validation
- reproduced the workflow locally on Windows with .NET 10
- full solution build: 0 errors
- tests: 342 passed, 0 failed

The four build warnings are pre-existing and are already addressed separately by PR #16.