### PR TITLE
Expand live character administration

### DIFF
--- a/Jondo.Unity.Server/Handlers/CommandHandler.cs
+++ b/Jondo.Unity.Server/Handlers/CommandHandler.cs
@@ -222,6 +222,32 @@ namespace Jondo.Unity.Server.Handlers
                 return;
             }
 
+            LevelChange result = await SetLevelAsync(stream, wanted);
+            string capped = result.Level != wanted ? T("level.requested", wanted) : "";
+            string omega = result.Level > MaxNormalLevel ? T("level.omega") : "";
+
+            await NotifyAsync(stream, T("level.result", result.Level, capped, result.PreviousLevel,
+                                         result.Experience, result.RemainingPoints,
+                                         result.Capital, result.SpellNote, omega), channel, accountId);
+        }
+
+        public sealed class LevelChange
+        {
+            public int PreviousLevel { get; init; }
+            public int Level { get; init; }
+            public long Experience { get; init; }
+            public int RemainingPoints { get; init; }
+            public int Capital { get; init; }
+            public string SpellNote { get; init; } = "";
+        }
+
+        /// <summary>
+        /// Applies the complete level transition and refreshes the client, without writing a chat
+        /// response. The chat command and the live administration endpoint share this path.
+        /// </summary>
+        public static async Task<LevelChange> SetLevelAsync(NetworkStream stream, int wanted)
+        {
+
             // El techo lo pone la tabla de experiencia del cliente, que llega al 1889. Sin ella
             // cargada no hay suelo de experiencia que poner y no se pasa del 200.
             int ceiling = ExperienceTable.IsLoaded ? ExperienceTable.MaxLevel : MaxNormalLevel;
@@ -255,7 +281,7 @@ namespace Jondo.Unity.Server.Handlers
             // StatsHandler y CharacteristicsHandler. Por encima de 200 se congela: los niveles
             // Omega no reparten puntos.
             int capital = StatsHandler.TotalCapitalForLevel(Math.Min(newLevel, MaxNormalLevel));
-            GameState.CharacterRemainingPoints = Math.Max(0, capital - SpentCapital());
+            GameState.CharacterRemainingPoints = Math.Max(0, capital - SpentCapital(capital));
 
             DatabaseManager.SaveCurrentCharacter();
 
@@ -296,17 +322,17 @@ namespace Jondo.Unity.Server.Handlers
 
             string spellNote = await RefreshSpellsAsync(stream, before);
 
-            string capped = newLevel != wanted ? T("level.requested", wanted) : "";
-            string omega = newLevel > MaxNormalLevel
-                ? T("level.omega")
-                : "";
-
-            await NotifyAsync(stream, T("level.result", newLevel, capped, oldLevel,
-                                         GameState.Experience, GameState.CharacterRemainingPoints,
-                                         capital, spellNote, omega), channel, accountId);
-
             Console.WriteLine($"[Comandos] Nivel {oldLevel} -> {newLevel}, experiencia " +
                               $"{GameState.Experience}, puntos {GameState.CharacterRemainingPoints}.");
+            return new LevelChange
+            {
+                PreviousLevel = oldLevel,
+                Level = newLevel,
+                Experience = GameState.Experience,
+                RemainingPoints = GameState.CharacterRemainingPoints,
+                Capital = capital,
+                SpellNote = spellNote,
+            };
         }
 
         /// <summary>
@@ -322,7 +348,7 @@ namespace Jondo.Unity.Server.Handlers
         /// Sin esa tabla cargada se cae al modelo por tramos de StatsHandler, que da lo mismo para
         /// las razas cuyo precio conocemos.
         /// </summary>
-        private static int SpentCapital()
+        private static int SpentCapital(int stopAfter = int.MaxValue)
         {
             if (!BreedStatCost.IsLoaded)
             {
@@ -347,6 +373,10 @@ namespace Jondo.Unity.Server.Handlers
                 for (int i = 0; i < points; i++)
                 {
                     spent += Math.Max(1, BreedStatCost.PriceOf(GameState.Breed, name, i));
+                    // The caller only needs to know that no capital remains. This also prevents a
+                    // live-admin character with millions of points from turning a level change
+                    // into millions of table lookups.
+                    if (spent > stopAfter) return spent;
                 }
             }
             return spent;
@@ -590,14 +620,15 @@ namespace Jondo.Unity.Server.Handlers
         /// Creates an item from the client template, with its real factory effects, persists it,
         /// updates both in-memory inventory views and immediately pushes it to the client.
         /// </summary>
-        private static async Task<bool> GiveItemAsync(NetworkStream stream, int gid, int quantity)
+        public static async Task<HavenBagStore.StoredItem?> GrantItemAsync(NetworkStream stream,
+                                                                           int gid, int quantity)
         {
-            if (!DatabaseManager.TryGetItemTemplateEffects(gid, out string effects)) return false;
+            if (!DatabaseManager.TryGetItemTemplateEffects(gid, out string effects)) return null;
 
             long uid = DatabaseManager.NextItemUid();
             if (!DatabaseManager.InsertCharacterItem(uid, GameState.CharacterId, gid, quantity,
                                                      Equipment.Bag, effects))
-                return false;
+                return null;
 
             Equipment.Add(uid, gid, quantity, Equipment.Bag, effects);
 
@@ -616,16 +647,16 @@ namespace Jondo.Unity.Server.Handlers
             }
             GameState.AddInventoryItem(legacy);
 
+            var granted = new HavenBagStore.StoredItem
+            {
+                Uid = uid,
+                Gid = gid,
+                Quantity = quantity,
+                Effects = effects,
+            };
             await NetworkMessage.WriteFrameAsync(stream,
-                ConnectionProtocol.Push(Op.Iua, ConnectionProtocol.BuildItemArrived(3,
-                    new HavenBagStore.StoredItem
-                    {
-                        Uid = uid,
-                        Gid = gid,
-                        Quantity = quantity,
-                        Effects = effects,
-                    })));
-            return true;
+                ConnectionProtocol.Push(Op.Iua, ConnectionProtocol.BuildItemArrived(3, granted)));
+            return granted;
         }
 
         private static async Task ItemAsync(NetworkStream stream, string rest,
@@ -651,7 +682,7 @@ namespace Jondo.Unity.Server.Handlers
                 return;
             }
 
-            if (!await GiveItemAsync(stream, gid, quantity))
+            if (await GrantItemAsync(stream, gid, quantity) == null)
             {
                 await NotifyAsync(stream, T("item.template_missing", gid), channel, accountId);
                 return;
@@ -682,7 +713,7 @@ namespace Jondo.Unity.Server.Handlers
             var missing = new List<int>();
             foreach (int gid in templates)
             {
-                if (await GiveItemAsync(stream, gid, 1)) added++;
+                if (await GrantItemAsync(stream, gid, 1) != null) added++;
                 else missing.Add(gid);
             }
 

--- a/Jondo.Unity.Server/Network/ControlApi.cs
+++ b/Jondo.Unity.Server/Network/ControlApi.cs
@@ -5,6 +5,7 @@ using System.IO;
 using System.Security.Cryptography;
 using System.Text.Json;
 using Jondo.Unity.Protocol;
+using Jondo.Unity.Server.Handlers;
 
 namespace Jondo.Unity.Server.Network
 {
@@ -165,10 +166,27 @@ namespace Jondo.Unity.Server.Network
         /// </summary>
         private static Respuesta AdministrarPersonaje(string cuerpo)
         {
-            string nombre = Texto(cuerpo, "personaje");
-            var sesion = SessionRegistry.FindByName(nombre);
+            if (!LiveCharacterUpdate.TryParse(cuerpo, out var update, out string error)
+                || update == null)
+                return Mal(400, error);
+            if (!update.HasChanges) return Mal(400, "sin-cambios");
+
+            var sesion = SessionRegistry.FindByName(update.Character);
             if (sesion == null || !sesion.HasCharacter || !sesion.IsInWorld)
                 return Mal(404, "personaje-desconectado");
+            if (sesion.Stream == null) return Mal(404, "personaje-desconectado");
+
+            // Validate every operation before touching the character. A bad mount or destination
+            // must not leave the earlier fields of the same request half-applied.
+            if (update.MapId.HasValue && MapManager.GetMapInfo(update.MapId.Value) == null)
+                return Mal(400, "mapa-desconocido");
+            if (update.ItemGid.HasValue
+                && !DatabaseManager.TryGetItemTemplateEffects((int)update.ItemGid.Value, out _))
+                return Mal(400, "objeto-desconocido");
+            if (update.MountGid.HasValue
+                && (!Managers.Mounts.IsRideable((int)update.MountGid.Value)
+                    || !DatabaseManager.TryGetItemTemplateEffects((int)update.MountGid.Value, out _)))
+                return Mal(400, "montura-invalida");
 
             // With a deadline, and not Wait() forever. This runs on the HttpListener's thread and
             // the lock is held across three socket writes: a client that has stopped reading -alt
@@ -183,29 +201,65 @@ namespace Jondo.Unity.Server.Network
                     var estado = sesion.State;
                     if (estado.IsInFight) return Mal(409, "personaje-en-combate");
 
-                    bool cambio = false;
-                    cambio |= AsignarEntero(cuerpo, "vitalidad", value => estado.StatVitality = value);
-                    cambio |= AsignarEntero(cuerpo, "sabiduria", value => estado.StatWisdom = value);
-                    cambio |= AsignarEntero(cuerpo, "fuerza", value => estado.StatStrength = value);
-                    cambio |= AsignarEntero(cuerpo, "inteligencia", value => estado.StatIntelligence = value);
-                    cambio |= AsignarEntero(cuerpo, "suerte", value => estado.StatChance = value);
-                    cambio |= AsignarEntero(cuerpo, "agilidad", value => estado.StatAgility = value);
-                    if (TryNumero(cuerpo, "kamas", out long kamas))
+                    bool sheetChanged = false;
+                    sheetChanged |= Assign(update.Vitality, value => estado.StatVitality = value);
+                    sheetChanged |= Assign(update.Wisdom, value => estado.StatWisdom = value);
+                    sheetChanged |= Assign(update.Strength, value => estado.StatStrength = value);
+                    sheetChanged |= Assign(update.Intelligence, value => estado.StatIntelligence = value);
+                    sheetChanged |= Assign(update.Chance, value => estado.StatChance = value);
+                    sheetChanged |= Assign(update.Agility, value => estado.StatAgility = value);
+                    bool kamasChanged = AssignKamas(update.Kamas, value => estado.Kamas = value);
+
+                    CommandHandler.LevelChange? levelChange = null;
+                    if (update.Level.HasValue)
                     {
-                        estado.Kamas = Math.Max(0, kamas);
-                        cambio = true;
+                        int requested = (int)Math.Clamp(update.Level.Value, int.MinValue, int.MaxValue);
+                        levelChange = CommandHandler.SetLevelAsync(sesion.Stream, requested)
+                            .GetAwaiter().GetResult();
                     }
 
-                    if (!cambio) return Mal(400, "sin-cambios");
+                    if (sheetChanged || kamasChanged)
+                    {
+                        DatabaseManager.SaveCurrentCharacter();
+                        sesion.SendAsync(ConnectionProtocol.Push(Op.Kub,
+                            ConnectionProtocol.BuildCharacteristics())).GetAwaiter().GetResult();
+                        sesion.SendAsync(ConnectionProtocol.Push(Op.Ivf,
+                            ConnectionProtocol.BuildKamas(estado.Kamas))).GetAwaiter().GetResult();
+                        sesion.SendAsync(ConnectionProtocol.Push(Op.Iun,
+                            ConnectionProtocol.BuildPods(0, 1000 + 5L * estado.StatStrength)))
+                            .GetAwaiter().GetResult();
+                    }
 
-                    DatabaseManager.SaveCurrentCharacter();
-                    sesion.SendAsync(ConnectionProtocol.Push(Op.Kub,
-                        ConnectionProtocol.BuildCharacteristics())).GetAwaiter().GetResult();
-                    sesion.SendAsync(ConnectionProtocol.Push(Op.Ivf,
-                        ConnectionProtocol.BuildKamas(estado.Kamas))).GetAwaiter().GetResult();
-                    sesion.SendAsync(ConnectionProtocol.Push(Op.Iun,
-                        ConnectionProtocol.BuildPods(0, 1000 + 5L * estado.StatStrength)))
-                        .GetAwaiter().GetResult();
+                    Managers.HavenBagStore.StoredItem? granted = null;
+                    if (update.ItemGid.HasValue)
+                    {
+                        granted = CommandHandler.GrantItemAsync(sesion.Stream,
+                            (int)update.ItemGid.Value, (int)(update.Quantity ?? 1))
+                            .GetAwaiter().GetResult();
+                    }
+
+                    Managers.HavenBagStore.StoredItem? mount = null;
+                    if (update.MountGid.HasValue)
+                    {
+                        mount = CommandHandler.GrantItemAsync(sesion.Stream,
+                            (int)update.MountGid.Value, 1).GetAwaiter().GetResult();
+                        if (mount != null)
+                        {
+                            byte[] move = ConnectionProtocol.Push(Op.Iuk, Pb.New()
+                                .Var(1, 1).Var(2, mount.Uid).Var(3, Managers.Mounts.Slot).Build());
+                            EquipmentHandler.MoveAsync(sesion.Stream, move, sesion.AccountId)
+                                .GetAwaiter().GetResult();
+                        }
+                    }
+
+                    int? landed = null;
+                    if (update.MapId.HasValue)
+                    {
+                        int targetCell = (int)Math.Clamp(update.Cell ?? TeleportHandler.MapCentre,
+                                                         0, int.MaxValue);
+                        landed = TeleportHandler.ToMapAsync(sesion.Stream, update.MapId.Value,
+                                                           targetCell).GetAwaiter().GetResult();
+                    }
 
                     Console.WriteLine($"[Control] Personaje {estado.CharacterName}: caracteristicas " +
                                       $"{estado.StatVitality}/{estado.StatWisdom}/{estado.StatStrength}/" +
@@ -222,6 +276,15 @@ namespace Jondo.Unity.Server.Network
                         suerte = estado.StatChance,
                         agilidad = estado.StatAgility,
                         kamas = estado.Kamas,
+                        nivel = estado.CharacterLevel,
+                        experiencia = estado.Experience,
+                        puntos = estado.CharacterRemainingPoints,
+                        nivelAnterior = levelChange?.PreviousLevel,
+                        mapa = estado.MapId,
+                        celda = estado.CellId,
+                        llegada = landed,
+                        objetoUid = granted?.Uid,
+                        monturaUid = mount?.Uid,
                     });
                 }
             }
@@ -250,10 +313,17 @@ namespace Jondo.Unity.Server.Network
         /// <summary>How long to wait for the session's turn before giving up on it.</summary>
         private static readonly TimeSpan PlazoDelTurno = TimeSpan.FromSeconds(5);
 
-        private static bool AsignarEntero(string cuerpo, string campo, Action<int> asignar)
+        private static bool Assign(long? raw, Action<int> assign)
         {
-            if (!TryNumero(cuerpo, campo, out long valor)) return false;
-            asignar((int)Math.Clamp(valor, 0, TopeDeCaracteristica));
+            if (!raw.HasValue) return false;
+            assign((int)Math.Clamp(raw.Value, 0, TopeDeCaracteristica));
+            return true;
+        }
+
+        private static bool AssignKamas(long? raw, Action<long> assign)
+        {
+            if (!raw.HasValue) return false;
+            assign(Math.Max(0, raw.Value));
             return true;
         }
 
@@ -466,17 +536,5 @@ namespace Jondo.Unity.Server.Network
             catch { return 0; }
         }
 
-        private static bool TryNumero(string json, string campo, out long valor)
-        {
-            valor = 0;
-            try
-            {
-                using var doc = JsonDocument.Parse(json.Length == 0 ? "{}" : json);
-                return doc.RootElement.TryGetProperty(campo, out var v)
-                       && v.ValueKind == JsonValueKind.Number
-                       && v.TryGetInt64(out valor);
-            }
-            catch { return false; }
-        }
     }
 }

--- a/Jondo.Unity.Server/Network/LiveCharacterUpdate.cs
+++ b/Jondo.Unity.Server/Network/LiveCharacterUpdate.cs
@@ -1,0 +1,130 @@
+using System;
+using System.Text.Json;
+
+namespace Jondo.Unity.Server.Network
+{
+    /// <summary>The validated, side-effect-free part of POST /api/personaje.</summary>
+    public sealed class LiveCharacterUpdate
+    {
+        public string Character { get; private init; } = "";
+        public long? Vitality { get; private init; }
+        public long? Wisdom { get; private init; }
+        public long? Strength { get; private init; }
+        public long? Intelligence { get; private init; }
+        public long? Chance { get; private init; }
+        public long? Agility { get; private init; }
+        public long? Kamas { get; private init; }
+        public long? Level { get; private init; }
+        public long? MapId { get; private init; }
+        public long? Cell { get; private init; }
+        public long? ItemGid { get; private init; }
+        public long? Quantity { get; private init; }
+        public long? MountGid { get; private init; }
+
+        public bool HasChanges => Vitality.HasValue || Wisdom.HasValue || Strength.HasValue
+            || Intelligence.HasValue || Chance.HasValue || Agility.HasValue || Kamas.HasValue
+            || Level.HasValue || MapId.HasValue || ItemGid.HasValue || MountGid.HasValue;
+
+        public static bool TryParse(string json, out LiveCharacterUpdate? update, out string error)
+        {
+            update = null;
+            error = "";
+            try
+            {
+                using var document = JsonDocument.Parse(string.IsNullOrWhiteSpace(json) ? "{}" : json);
+                if (document.RootElement.ValueKind != JsonValueKind.Object)
+                {
+                    error = "cuerpo-invalido";
+                    return false;
+                }
+
+                JsonElement root = document.RootElement;
+                string character = root.TryGetProperty("personaje", out var name)
+                                   && name.ValueKind == JsonValueKind.String
+                    ? name.GetString() ?? ""
+                    : "";
+
+                if (!Read(root, "vitalidad", out long? vitality, out error)
+                    || !Read(root, "sabiduria", out long? wisdom, out error)
+                    || !Read(root, "fuerza", out long? strength, out error)
+                    || !Read(root, "inteligencia", out long? intelligence, out error)
+                    || !Read(root, "suerte", out long? chance, out error)
+                    || !Read(root, "agilidad", out long? agility, out error)
+                    || !Read(root, "kamas", out long? kamas, out error)
+                    || !Read(root, "nivel", out long? level, out error)
+                    || !Read(root, "mapa", out long? mapId, out error)
+                    || !Read(root, "celda", out long? cell, out error)
+                    || !Read(root, "objeto", out long? item, out error)
+                    || !Read(root, "cantidad", out long? quantity, out error)
+                    || !Read(root, "montura", out long? mount, out error))
+                    return false;
+
+                if (cell.HasValue && !mapId.HasValue)
+                {
+                    error = "celda-sin-mapa";
+                    return false;
+                }
+                if (quantity.HasValue && !item.HasValue)
+                {
+                    error = "cantidad-sin-objeto";
+                    return false;
+                }
+                if (item.HasValue && (item <= 0 || item > int.MaxValue
+                    || (quantity ?? 1) <= 0 || (quantity ?? 1) > 1_000_000))
+                {
+                    error = "objeto-invalido";
+                    return false;
+                }
+                if (mount.HasValue && (mount <= 0 || mount > int.MaxValue))
+                {
+                    error = "montura-invalida";
+                    return false;
+                }
+                if (mapId.HasValue && mapId <= 0)
+                {
+                    error = "mapa-invalido";
+                    return false;
+                }
+
+                update = new LiveCharacterUpdate
+                {
+                    Character = character.Trim(),
+                    Vitality = vitality,
+                    Wisdom = wisdom,
+                    Strength = strength,
+                    Intelligence = intelligence,
+                    Chance = chance,
+                    Agility = agility,
+                    Kamas = kamas,
+                    Level = level,
+                    MapId = mapId,
+                    Cell = cell,
+                    ItemGid = item,
+                    Quantity = quantity,
+                    MountGid = mount,
+                };
+                return true;
+            }
+            catch (JsonException)
+            {
+                error = "cuerpo-invalido";
+                return false;
+            }
+        }
+
+        private static bool Read(JsonElement root, string name, out long? value, out string error)
+        {
+            value = null;
+            error = "";
+            if (!root.TryGetProperty(name, out var property)) return true;
+            if (property.ValueKind == JsonValueKind.Number && property.TryGetInt64(out long number))
+            {
+                value = number;
+                return true;
+            }
+
+            error = "campo-invalido-" + name;
+            return false;
+        }
+    }
+}

--- a/Jondo.Unity.Tests/Sessions/LiveCharacterUpdateTests.cs
+++ b/Jondo.Unity.Tests/Sessions/LiveCharacterUpdateTests.cs
@@ -1,0 +1,78 @@
+using Jondo.Unity.Server.Network;
+using Xunit;
+
+namespace Jondo.Unity.Tests.Sessions
+{
+    public class LiveCharacterUpdateTests
+    {
+        [Fact]
+        public void One_request_can_describe_every_supported_live_action()
+        {
+            const string json = """
+                {
+                  "personaje": "Ty",
+                  "nivel": 200,
+                  "mapa": 88212759,
+                  "celda": 321,
+                  "objeto": 1234,
+                  "cantidad": 3,
+                  "montura": 5678,
+                  "sabiduria": 500,
+                  "kamas": 50000
+                }
+                """;
+
+            bool parsed = LiveCharacterUpdate.TryParse(json, out var update, out string error);
+
+            Assert.True(parsed, error);
+            Assert.NotNull(update);
+            Assert.True(update.HasChanges);
+            Assert.Equal("Ty", update.Character);
+            Assert.Equal(200, update.Level);
+            Assert.Equal(88212759, update.MapId);
+            Assert.Equal(321, update.Cell);
+            Assert.Equal(1234, update.ItemGid);
+            Assert.Equal(3, update.Quantity);
+            Assert.Equal(5678, update.MountGid);
+            Assert.Equal(500, update.Wisdom);
+            Assert.Equal(50000, update.Kamas);
+        }
+
+        [Fact]
+        public void Numeric_fields_do_not_accept_strings()
+        {
+            bool parsed = LiveCharacterUpdate.TryParse(
+                "{\"personaje\":\"Ty\",\"niveau\":\"200\",\"nivel\":\"200\"}",
+                out _, out string error);
+
+            Assert.False(parsed);
+            Assert.Equal("campo-invalido-nivel", error);
+        }
+
+        [Theory]
+        [InlineData("{\"personaje\":\"Ty\",\"celda\":1}", "celda-sin-mapa")]
+        [InlineData("{\"personaje\":\"Ty\",\"cantidad\":1}", "cantidad-sin-objeto")]
+        [InlineData("{\"personaje\":\"Ty\",\"objeto\":1,\"cantidad\":0}", "objeto-invalido")]
+        [InlineData("{\"personaje\":\"Ty\",\"montura\":0}", "montura-invalida")]
+        [InlineData("{\"personaje\":\"Ty\",\"mapa\":0}", "mapa-invalido")]
+        public void Dependent_and_identifier_fields_are_validated(string json, string expected)
+        {
+            bool parsed = LiveCharacterUpdate.TryParse(json, out _, out string error);
+
+            Assert.False(parsed);
+            Assert.Equal(expected, error);
+        }
+
+        [Fact]
+        public void An_empty_patch_is_valid_but_has_no_changes()
+        {
+            bool parsed = LiveCharacterUpdate.TryParse(
+                "{\"personaje\":\"Ty\",\"token\":\"not-read-by-this-parser\"}",
+                out var update, out string error);
+
+            Assert.True(parsed, error);
+            Assert.NotNull(update);
+            Assert.False(update.HasChanges);
+        }
+    }
+}

--- a/README.md
+++ b/README.md
@@ -133,7 +133,7 @@ Not in the repository because they are not needed to play: `bases/` (built on fi
 - ✅ **17,113 spells** across **34,823 spell levels**; **638 character heads**
 - ✅ **539 titles** and **167 ornaments**, applied, persisted and carried in the map actor block
 - ✅ Commands — `.teleport`, `.kamas`, `.shop`, `.size`, `.level`, `.item`, `.itemset`
-- ✅ **Live administration over HTTP** — `POST /api/personaje` sets base characteristics and kamas on a connected character, persists them and refreshes the sheet without a reconnect. Administrator role only, loopback only, and it takes the session's turn so it cannot cut across a fight
+- ✅ **Live administration over HTTP** — `POST /api/personaje` sets characteristics, kamas and level, grants items or a mount, and teleports a connected character without a reconnect. `POST /api/rol` changes account roles. Administrator only, loopback only, and serialized with the target session
 - 🟡 `.level` does not refresh the in-fight spell bar
 
 ### 👕 Appearances

--- a/docs/live-character-admin.md
+++ b/docs/live-character-admin.md
@@ -1,8 +1,9 @@
 # Live character administration
 
-The control API can change an online character's base characteristics and kamas without restarting
-the server or making the player reconnect. It is intended for local administration tools that need
-the same immediate feedback as an in-game command.
+The control API can change an online character without restarting the server or making the player
+reconnect. It can update base characteristics, kamas and level, grant an item, grant and equip a
+mount, or teleport the character. It is intended for local administration tools that need the same
+immediate feedback as an in-game command.
 
 ## Request
 
@@ -20,13 +21,21 @@ change:
   "inteligencia": 250,
   "suerte": 250,
   "agilidad": 250,
-  "kamas": 50000
+  "kamas": 50000,
+  "nivel": 200,
+  "mapa": 88212759,
+  "celda": 321,
+  "objeto": 1234,
+  "cantidad": 3,
+  "montura": 5678
 }
 ```
 
-Every value after `personaje` is optional. Characteristic values are clamped to the range from zero
-to `Int32.MaxValue`; kamas cannot be negative. The response contains the complete set of resulting
-base values, not only the fields that changed.
+Every value after `personaje` is optional. Characteristic values are clamped from zero to
+10,000,000 and kamas cannot be negative. Item quantities are limited to 1,000,000. `celda` is
+optional but only valid with `mapa`; the nearest walkable cell is used. `montura` must identify a
+rideable item template. The response contains the complete resulting character state and the UIDs
+of newly granted objects.
 
 The caller is authenticated through the same launcher token and database role check used by the
 other control routes. The HAAPI listener is bound to loopback, and the request log redacts the token.
@@ -34,23 +43,34 @@ The target character must be connected and outside a fight.
 
 ## What changes immediately
 
-The server serializes the operation with the target session's normal packet processing, then:
+The server validates every requested operation first, serializes it with the target session's
+normal packet processing, then performs the requested subset:
 
-1. changes the in-memory base values;
-2. saves the character through `DatabaseManager.SaveCurrentCharacter()`;
-3. sends refreshed characteristics, kamas and pod capacity to that character.
+1. changes and persists base values, kamas and the complete level/experience/capital transition;
+2. refreshes characteristics, kamas, pods, known spells and shortcut bars;
+3. creates requested items with their template effects and pushes them into the inventory;
+4. equips a requested mount through the normal equipment path, including appearance refresh;
+5. teleports through the normal map-change path and announces departure to nearby sessions.
 
 No client restart, server restart or direct database edit is required.
 
-The endpoint deliberately does not change character level. A level change also has to reconcile
-experience, characteristic capital, spell points, known spell grades and the level-up packet; the
-existing administrator `.level` command owns that complete transition.
+To change an account role, use `POST /api/rol` with the same administrator token:
+
+```json
+{ "token": "<administrator launcher token>", "cuenta": "login", "rol": 5 }
+```
+
+The role is clamped to the supported range documented in `docs/role.md`.
 
 ## Errors
 
 | HTTP status | Error | Meaning |
 |---|---|---|
 | 400 | `sin-cambios` | No supported numeric field was supplied. |
+| 400 | `campo-invalido-*` | A supported field was supplied with a non-numeric value. |
+| 400 | `objeto-desconocido` | The requested item template does not exist. |
+| 400 | `montura-invalida` | The requested template is not a rideable mount. |
+| 400 | `mapa-desconocido` | The destination is absent from the world map catalogue. |
 | 401 | `sesion` | The launcher token is absent or expired. |
 | 403 | `rol` | The token belongs to an account below administrator. |
 | 404 | `personaje-desconectado` | No connected character matches the supplied name. |


### PR DESCRIPTION
## Summary
- extend POST /api/personaje with nivel, mapa plus optional celda, objeto plus optional cantidad, and montura
- keep existing stat and kamas mutations and document the existing POST /api/rol endpoint
- validate the complete request before changing live state
- reject unsafe mutations during a fight and serialize changes through the player session
- reuse the real command, item grant and equipment paths so client state and persistence stay synchronized
- avoid unnecessary characteristic-cost iteration for very large administrative values

## Validation
- 350 tests passed, 0 failed
- parser and validation tests cover accepted operations, invalid combinations, rideable mounts and no-partial-mutation behavior