### PR TITLE
Keep combat spell bars in sync

### DIFF
--- a/Jondo.Unity.Server/Handlers/CommandHandler.cs
+++ b/Jondo.Unity.Server/Handlers/CommandHandler.cs
@@ -295,6 +295,7 @@ namespace Jondo.Unity.Server.Handlers
                 ConnectionProtocol.Push(Op.Kub, ConnectionProtocol.BuildCharacteristics()));
 
             string spellNote = await RefreshSpellsAsync(stream, before);
+            await FightHandler.RefreshPlayerSpellBarAsync(stream);
 
             string capped = newLevel != wanted ? T("level.requested", wanted) : "";
             string omega = newLevel > MaxNormalLevel

--- a/Jondo.Unity.Server/Handlers/FightHandler.cs
+++ b/Jondo.Unity.Server/Handlers/FightHandler.cs
@@ -1506,30 +1506,10 @@ namespace Jondo.Unity.Server.Handlers
             // que puede estar a medio llenar, y por eso el cliente enseñaba todos los hechizos
             // durante la colocación —los suyos, de antes— y se quedaba en blanco al empezar el
             // turno, cuando por fin le llegaba nuestra lista corta.
-            var spells = new List<(int Spell, int Grade)>();
-            foreach (var spell in Managers.SpellTable.KnownFor(character?.Breed ?? 0,
-                                                               GameState.CharacterLevel,
-                                                               Managers.SpellChoices.Chosen))
-            {
-                spells.Add((spell.SpellId, spell.Grade));
-            }
-            // Dónde va cada uno en el panel: lo que el jugador tenga puesto, y si no tiene nada
-            // puesto, los suyos en orden, que es mejor que dejarle el panel en blanco.
-            var bar = new List<(int Slot, int Spell)>();
-            foreach (var slot in Managers.SpellChoices.Bar)
-            {
-                if (slot.Value != 0) bar.Add((slot.Key, slot.Value));
-            }
-            if (bar.Count == 0)
-            {
-                for (int i = 0; i < spells.Count; i++) bar.Add((i + 1, spells[i].Spell));
-            }
-
-            // Y el cuerpo a cuerpo en el primer hueco que quede libre. Es una entrada de la barra
-            // como cualquier otra, sólo que con el hechizo cero, y va SIEMPRE: no depende de que
-            // se lleve arma equipada.
-            bar.Add((PrimerHuecoLibre(bar), Network.FightProtocol.HechizoCuerpoACuerpo));
-            bar.Sort((a, b) => a.Slot.CompareTo(b.Slot));
+            var spellLayout = Managers.FightSpellLayout.Current(character?.Breed ?? 0,
+                                                                 GameState.CharacterLevel);
+            var spells = spellLayout.Spells;
+            var bar = spellLayout.Bar;
 
             await WriteFrameAsync(stream, ConnectionProtocol.Push(Op.Jyy,
                 Network.FightProtocol.BuildSpellBar(me, spells, bar)));
@@ -2442,20 +2422,6 @@ namespace Jondo.Unity.Server.Handlers
 
             await WriteFrameAsync(stream, ConnectionProtocol.Push(Op.Jzu,
                 Network.FightProtocol.BuildTeams(todos)));
-        }
-
-        /// <summary>
-        /// El primer hueco de la barra que no tenga nada, para meter ahí el cuerpo a cuerpo. En
-        /// las capturas casi siempre es el cero, pero no siempre: hay jugadores que lo tienen en
-        /// el 12, el 21, el 24, el 31 o el 49 porque llenaron los de delante a mano.
-        /// </summary>
-        private static int PrimerHuecoLibre(List<(int Slot, int Spell)> bar)
-        {
-            var ocupados = new HashSet<int>();
-            foreach (var (slot, _) in bar) ocupados.Add(slot);
-            int hueco = 0;
-            while (ocupados.Contains(hueco)) hueco++;
-            return hueco;
         }
 
         /// <summary>La característica 26, que el cliente pinta como "Invocación" en el panel.</summary>
@@ -4151,14 +4117,14 @@ namespace Jondo.Unity.Server.Handlers
         {
             var jvnMsg = new ProtoMessage();
 
-            // Same list as the roleplay shortcut bar.
-            // TODO: once "which variant the player picked" is persisted, read it in
-            // GetPlayerAvailableSpells instead of always assuming the base one.
-            var spellList = DatabaseManager.GetPlayerAvailableSpells(GameState.Breed, GameState.CharacterLevel);
+            // Same chosen variants and saved shortcuts as the roleplay and live combat bars.
+            var layout = Managers.FightSpellLayout.Current(GameState.Breed,
+                                                           GameState.CharacterLevel);
+            var spellList = layout.Spells;
 
             Program.LogDebug($"[FightHandler] jvn: {spellList.Count} spells available at level " +
                              $"{GameState.CharacterLevel} for breed {GameState.Breed}: " +
-                             string.Join(", ", spellList));
+                             string.Join(", ", spellList.Select(spell => spell.Spell)));
 
             // First entry: the WEAPON. It carries no spell id and uses f3 = 2 (spells use f3 = 1).
             // It was missing, and that is why the sword icon vanished from the bar on entering a
@@ -4167,7 +4133,7 @@ namespace Jondo.Unity.Server.Handlers
             weaponSub.Fields.Add(new ProtoField { FieldNumber = 3, WireType = 0, VarIntValue = 2 });
             weaponSub.Fields.Add(new ProtoField { FieldNumber = 4, WireType = 0, VarIntValue = 1 });
             jvnMsg.Fields.Add(new ProtoField { FieldNumber = 1, WireType = 2, BytesValue = weaponSub.ToByteArray() });
-            foreach (var spellId in spellList)
+            foreach (var (spellId, _) in spellList)
             {
                 var sSub = new ProtoMessage();
                 sSub.Fields.Add(new ProtoField { FieldNumber = 1, WireType = 0, VarIntValue = spellId });
@@ -4179,20 +4145,25 @@ namespace Jondo.Unity.Server.Handlers
             jvnMsg.Fields.Add(new ProtoField { FieldNumber = 4, WireType = 0, VarIntValue = GameState.CharacterId });
             jvnMsg.Fields.Add(new ProtoField { FieldNumber = 5, WireType = 0, VarIntValue = GameState.CharacterId });
 
-            // Slot 0 left empty, just like the official capture and the itp: that is the weapon slot.
-            var weaponSlot = new ProtoMessage();
-            weaponSlot.Fields.Add(new ProtoField { FieldNumber = 4, WireType = 2, BytesValue = Array.Empty<byte>() });
-            jvnMsg.Fields.Add(new ProtoField { FieldNumber = 6, WireType = 2, BytesValue = weaponSlot.ToByteArray() });
-
-            int slot = 1;
-            foreach (var spellId in spellList)
+            foreach (var (slot, spellId) in layout.Bar)
             {
-                var spSub = new ProtoMessage();
-                spSub.Fields.Add(new ProtoField { FieldNumber = 1, WireType = 0, VarIntValue = spellId });
-
                 var slotSub = new ProtoMessage();
-                slotSub.Fields.Add(new ProtoField { FieldNumber = 3, WireType = 0, VarIntValue = slot++ });
-                slotSub.Fields.Add(new ProtoField { FieldNumber = 4, WireType = 2, BytesValue = spSub.ToByteArray() });
+                if (slot != 0)
+                    slotSub.Fields.Add(new ProtoField { FieldNumber = 3, WireType = 0, VarIntValue = slot });
+
+                if (spellId == Network.FightProtocol.HechizoCuerpoACuerpo)
+                {
+                    slotSub.Fields.Add(new ProtoField
+                        { FieldNumber = 4, WireType = 2, BytesValue = Array.Empty<byte>() });
+                }
+                else
+                {
+                    var spell = new ProtoMessage();
+                    spell.Fields.Add(new ProtoField
+                        { FieldNumber = 1, WireType = 0, VarIntValue = spellId });
+                    slotSub.Fields.Add(new ProtoField
+                        { FieldNumber = 4, WireType = 2, BytesValue = spell.ToByteArray() });
+                }
 
                 jvnMsg.Fields.Add(new ProtoField { FieldNumber = 6, WireType = 2, BytesValue = slotSub.ToByteArray() });
             }
@@ -4200,6 +4171,25 @@ namespace Jondo.Unity.Server.Handlers
             byte[] env = BuildGameNodePacket("type.ankama.com/jvn", jvnMsg.ToByteArray());
             await WriteFrameAsync(stream, env);
             Program.LogDebug($"[FightHandler] Sent jvn (SpellListMessage) with {spellList.Count} spells for Breed {GameState.Breed}.");
+        }
+
+        /// <summary>
+        /// Rebuilds the live jyy bar after an administrative level change or a variant switch.
+        /// Outside a fight hms and itg remain the authoritative messages, so there is nothing to
+        /// send here.
+        /// </summary>
+        public static async Task RefreshPlayerSpellBarAsync(NetworkStream stream)
+        {
+            if (!GameState.IsInFight || !Managers.SpellTable.IsLoaded || GetCurrentFight() == null)
+                return;
+
+            var layout = Managers.FightSpellLayout.Current(GameState.Breed,
+                                                           GameState.CharacterLevel);
+            await WriteFrameAsync(stream, ConnectionProtocol.Push(Op.Jyy,
+                Network.FightProtocol.BuildSpellBar(GameState.CharacterId,
+                                                    layout.Spells, layout.Bar)));
+            Program.LogDebug($"[FightHandler] Refreshed the in-fight spell bar with " +
+                             $"{layout.Spells.Count} spells at level {GameState.CharacterLevel}.");
         }
 
         public static async Task SendFighterResync(NetworkStream stream, FightInstance fight)

--- a/Jondo.Unity.Server/Handlers/SpellHandler.cs
+++ b/Jondo.Unity.Server/Handlers/SpellHandler.cs
@@ -67,6 +67,8 @@ namespace Jondo.Unity.Server.Handlers
             await Jondo.Protocol.NetworkMessage.WriteFrameAsync(stream,
                 ConnectionProtocol.Push(Op.Hng, ConnectionProtocol.BuildSpellSwapped(wanted, grade)));
 
+            await FightHandler.RefreshPlayerSpellBarAsync(stream);
+
             Console.WriteLine($"[Hechizos] Pareja {pair.Id}: {leaving} -> {wanted} (grado {grade}), " +
                               $"{slots.Count} hueco(s) de la barra actualizados.");
         }

--- a/Jondo.Unity.Server/Managers/FightSpellLayout.cs
+++ b/Jondo.Unity.Server/Managers/FightSpellLayout.cs
@@ -1,0 +1,70 @@
+using System.Collections.Generic;
+
+namespace Jondo.Unity.Server.Managers
+{
+    /// <summary>
+    /// The single source of truth for the player's combat spell list and shortcuts. Both the
+    /// placement message (jvn) and the live combat bar (jyy) must carry the same variant choices.
+    /// </summary>
+    public static class FightSpellLayout
+    {
+        public const int SlotCount = 40;
+
+        public sealed class Layout
+        {
+            public List<(int Spell, int Grade)> Spells { get; } = new();
+            public List<(int Slot, int Spell)> Bar { get; } = new();
+        }
+
+        public static Layout Current(int breed, int level)
+            => Build(SpellTable.KnownFor(breed, level, SpellChoices.Chosen), SpellChoices.Bar);
+
+        /// <summary>
+        /// Keeps valid saved shortcuts, drops spells lost after a level or variant change, fills
+        /// newly opened spells into free slots, and reserves one slot for close combat (spell 0).
+        /// </summary>
+        public static Layout Build(IEnumerable<SpellTable.KnownSpell> known,
+                                   IReadOnlyDictionary<int, int> savedBar)
+        {
+            var layout = new Layout();
+            var available = new HashSet<int>();
+            foreach (var spell in known)
+            {
+                layout.Spells.Add((spell.SpellId, spell.Grade));
+                available.Add(spell.SpellId);
+            }
+
+            var occupiedSlots = new HashSet<int>();
+            var placedSpells = new HashSet<int>();
+            foreach (var saved in savedBar)
+            {
+                if (saved.Key < 0 || saved.Key >= SlotCount || !available.Contains(saved.Value))
+                    continue;
+
+                layout.Bar.Add((saved.Key, saved.Value));
+                occupiedSlots.Add(saved.Key);
+                placedSpells.Add(saved.Value);
+            }
+
+            int next = 1; // Slot zero is normally the close-combat shortcut.
+            foreach (var spell in layout.Spells)
+            {
+                if (placedSpells.Contains(spell.Spell)) continue;
+                while (next < SlotCount && occupiedSlots.Contains(next)) next++;
+                if (next >= SlotCount) break;
+
+                layout.Bar.Add((next, spell.Spell));
+                occupiedSlots.Add(next);
+                placedSpells.Add(spell.Spell);
+                next++;
+            }
+
+            int weaponSlot = 0;
+            while (weaponSlot < SlotCount && occupiedSlots.Contains(weaponSlot)) weaponSlot++;
+            if (weaponSlot < SlotCount) layout.Bar.Add((weaponSlot, Network.FightProtocol.HechizoCuerpoACuerpo));
+
+            layout.Bar.Sort((left, right) => left.Slot.CompareTo(right.Slot));
+            return layout;
+        }
+    }
+}

--- a/Jondo.Unity.Server/Network/ConnectionProtocol.cs
+++ b/Jondo.Unity.Server/Network/ConnectionProtocol.cs
@@ -1038,63 +1038,24 @@ namespace Jondo.Unity.Server.Network
         /// </summary>
         public static byte[] BuildSpellBar(int breed, int level)
         {
-            var known = SpellTable.KnownFor(breed, level, Managers.SpellChoices.Chosen);
+            var layout = Managers.FightSpellLayout.Current(breed, level);
 
-            // Un hechizo que ya no se tiene —porque se cambió de variante— no puede quedarse en la
-            // barra: el cliente pinta un hueco que no sabe resolver.
-            var has = new HashSet<int>();
-            foreach (var spell in known) has.Add(spell.SpellId);
-
-            var placed = new List<(int Slot, int SpellId)>();
-            var taken = new HashSet<int>();
-            foreach (var pair in Managers.SpellChoices.Bar)
+            var remembered = new List<(int Slot, int SpellId)>();
+            foreach (var (slot, spell) in layout.Bar)
             {
-                if (pair.Key >= SpellBarSlots || !has.Contains(pair.Value)) continue;
-                placed.Add((pair.Key, pair.Value));
-                taken.Add(pair.Value);
+                if (spell != Network.FightProtocol.HechizoCuerpoACuerpo)
+                    remembered.Add((slot, spell));
             }
-
-            // Y lo que el jugador todavía no ha colocado se reparte por los huecos libres, que es
-            // lo que hace el juego con un personaje recién hecho.
-            //
-            // Empezando por el UNO: el hueco cero es donde el cliente dibuja el arma, y en 37 de
-            // las 51 barras de las capturas va vacío por eso mismo.
-            int next = 1;
-            foreach (var spell in known)
-            {
-                if (taken.Contains(spell.SpellId)) continue;
-                while (next < SpellBarSlots && placed.Exists(p => p.Slot == next)) next++;
-                if (next >= SpellBarSlots) break;
-                placed.Add((next, spell.SpellId));
-                next++;
-            }
-
-            placed.Sort((a, b) => a.Slot.CompareTo(b.Slot));
-            Managers.SpellChoices.RememberBar(placed);
-
-            // El cuerpo a cuerpo va en el primer hueco libre, con el hechizo CERO. Su entrada es
-            // un f6 presente y vacío —los bytes 0a 02 32 00—, que es como proto3 escribe el cero.
-            // Está en las 13 barras de jugador de las capturas, incluida la del personaje del
-            // tutorial, que no lleva ni un objeto: la casilla es la del puño y va siempre.
-            var ocupados = new HashSet<int>();
-            foreach (var (slot, _) in placed) ocupados.Add(slot);
-            int hueco = 0;
-            while (ocupados.Contains(hueco)) hueco++;
+            Managers.SpellChoices.RememberBar(remembered);
 
             var itg = Pb.New();
-            bool puesto = false;
-            foreach (var (slot, spellId) in placed)
+            foreach (var (slot, spell) in layout.Bar)
             {
-                if (!puesto && hueco < slot)
-                {
-                    itg.Msg(1, Pb.New().VarIfNotZero(2, hueco).EmptyMsg(6));
-                    puesto = true;
-                }
-                itg.Msg(1, Pb.New()
-                    .VarIfNotZero(2, slot)
-                    .Msg(6, Pb.New().Var(2, spellId)));
+                var shortcut = Pb.New().VarIfNotZero(2, slot);
+                if (spell == Network.FightProtocol.HechizoCuerpoACuerpo) shortcut.EmptyMsg(6);
+                else shortcut.Msg(6, Pb.New().Var(2, spell));
+                itg.Msg(1, shortcut);
             }
-            if (!puesto) itg.Msg(1, Pb.New().VarIfNotZero(2, hueco).EmptyMsg(6));
 
             return itg.Var(2, SpellBar).Build();
         }
@@ -1124,7 +1085,6 @@ namespace Jondo.Unity.Server.Network
                 .Build();
 
         /// <summary>How many slots of the bar we fill. The captured one runs from 0 to 48.</summary>
-        private const int SpellBarSlots = 40;
 
         // ─── World: weight carried ──────────────────────────────────────────────
 

--- a/Jondo.Unity.Tests/Combat/FightSpellLayoutTests.cs
+++ b/Jondo.Unity.Tests/Combat/FightSpellLayoutTests.cs
@@ -1,0 +1,66 @@
+using System.Collections.Generic;
+using Jondo.Unity.Server.Managers;
+using Jondo.Unity.Server.Network;
+using Xunit;
+
+namespace Jondo.Unity.Tests.Combat
+{
+    public class FightSpellLayoutTests
+    {
+        [Fact]
+        public void A_stale_base_shortcut_is_replaced_by_the_available_variant()
+        {
+            var known = new[] { new SpellTable.KnownSpell(7, 200, 4) };
+            var saved = new Dictionary<int, int> { [6] = 100 };
+
+            var layout = FightSpellLayout.Build(known, saved);
+
+            Assert.Equal(new[] { (200, 4) }, layout.Spells);
+            Assert.DoesNotContain(layout.Bar, entry => entry.Spell == 100);
+            Assert.Contains((1, 200), layout.Bar);
+            Assert.Contains((0, FightProtocol.HechizoCuerpoACuerpo), layout.Bar);
+        }
+
+        [Fact]
+        public void Valid_custom_slots_are_preserved_and_new_spells_fill_free_slots()
+        {
+            var known = new[]
+            {
+                new SpellTable.KnownSpell(1, 101, 2),
+                new SpellTable.KnownSpell(2, 202, 3),
+                new SpellTable.KnownSpell(3, 303, 1),
+            };
+            var saved = new Dictionary<int, int> { [5] = 202, [9] = 101 };
+
+            var layout = FightSpellLayout.Build(known, saved);
+
+            Assert.Contains((5, 202), layout.Bar);
+            Assert.Contains((9, 101), layout.Bar);
+            Assert.Contains((1, 303), layout.Bar);
+            Assert.Contains((0, FightProtocol.HechizoCuerpoACuerpo), layout.Bar);
+        }
+
+        [Fact]
+        public void Close_combat_uses_the_first_free_slot_when_zero_is_occupied()
+        {
+            var known = new[] { new SpellTable.KnownSpell(1, 101, 1) };
+            var saved = new Dictionary<int, int> { [0] = 101 };
+
+            var layout = FightSpellLayout.Build(known, saved);
+
+            Assert.Equal(new[] { (0, 101), (1, FightProtocol.HechizoCuerpoACuerpo) }, layout.Bar);
+        }
+
+        [Fact]
+        public void Shortcuts_outside_the_protocol_bar_are_ignored()
+        {
+            var known = new[] { new SpellTable.KnownSpell(1, 101, 1) };
+            var saved = new Dictionary<int, int> { [FightSpellLayout.SlotCount] = 101 };
+
+            var layout = FightSpellLayout.Build(known, saved);
+
+            Assert.Contains((1, 101), layout.Bar);
+            Assert.DoesNotContain(layout.Bar, entry => entry.Slot >= FightSpellLayout.SlotCount);
+        }
+    }
+}

--- a/README.md
+++ b/README.md
@@ -134,7 +134,7 @@ Not in the repository because they are not needed to play: `bases/` (built on fi
 - ✅ **539 titles** and **167 ornaments**, applied, persisted and carried in the map actor block
 - ✅ Commands — `.teleport`, `.kamas`, `.shop`, `.size`, `.level`, `.item`, `.itemset`
 - ✅ **Live administration over HTTP** — `POST /api/personaje` sets base characteristics and kamas on a connected character, persists them and refreshes the sheet without a reconnect. Administrator role only, loopback only, and it takes the session's turn so it cannot cut across a fight
-- 🟡 `.level` does not refresh the in-fight spell bar
+- ✅ `.level` and variant changes refresh the same selected spells and shortcuts in combat
 
 ### 👕 Appearances
 Dofus does not ship the item-to-look table: the server sends it. **2,371 of the 2,420 cosmetics** in the catalogue were measured off captures, one garment at a time.


### PR DESCRIPTION
## Summary
- build roleplay, preparation and active-combat spell bars from one FightSpellLayout source
- keep valid player shortcut slots while removing stale spell-variant shortcuts
- fill newly unlocked spells deterministically and include close combat
- refresh the active combat spell bar after a level change or spell-variant switch
- mark the corresponding combat roadmap item complete

## Validation
- 346 tests passed, 0 failed
- regression coverage verifies stale variant removal, new-spell insertion, stable custom slots and the close-combat shortcut