### PR TITLE
Back up databases before migrations

### DIFF
--- a/Jondo.Unity.Core/Paths.cs
+++ b/Jondo.Unity.Core/Paths.cs
@@ -106,6 +106,7 @@ namespace Jondo.Unity.Launcher
         public static string WorldDb => ResolveWritable("world.db", DatabaseFolder);
         public static string AuthDb => ResolveWritable("auth.db", DatabaseFolder);
         public static string WorldZip => Resolve("world.zip");
+        public static string DatabaseBackupsDir => Path.Combine(Root, DatabaseFolder, "backups");
 
         /// <summary>
         /// La base de diagnóstico donde se apuntan los paquetes que no sabemos atender.

--- a/Jondo.Unity.Server/Managers/DatabaseBackups.cs
+++ b/Jondo.Unity.Server/Managers/DatabaseBackups.cs
@@ -1,0 +1,215 @@
+using Jondo.Unity.Launcher;
+using Microsoft.Data.Sqlite;
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Text.Json;
+
+namespace Jondo.Unity.Server
+{
+    /// <summary>
+    /// Consistent SQLite snapshots taken before DatabaseManager is allowed to migrate anything.
+    /// BackupDatabase includes committed WAL pages; copying only the .db file would not.
+    /// </summary>
+    public static class DatabaseBackups
+    {
+        public const int DefaultRetention = 5;
+
+        public sealed class Result
+        {
+            public string Directory { get; init; } = "";
+            public IReadOnlyList<string> Files { get; init; } = Array.Empty<string>();
+        }
+
+        public static Result? CreateBeforeMigration()
+        {
+            var databases = new[] { Paths.AuthDb, Paths.WorldDb }
+                .Where(File.Exists)
+                .ToArray();
+            if (databases.Length == 0)
+            {
+                Console.WriteLine("[SQLite] No existing databases to back up on first start.");
+                return null;
+            }
+
+            try
+            {
+                Result result = Create(databases, Paths.DatabaseBackupsDir, DefaultRetention);
+                Console.WriteLine($"[SQLite] Verified backup created in {result.Directory} " +
+                                  $"({result.Files.Count} database(s), keeping {DefaultRetention}).");
+                return result;
+            }
+            catch (Exception ex)
+            {
+                Console.WriteLine($"[SQLite][ERROR] Pre-migration backup failed: {ex.Message}");
+                Console.WriteLine("[SQLite][ERROR] Database initialization cancelled to preserve existing data.");
+                throw;
+            }
+        }
+
+        /// <summary>Creates and verifies one backup set, then removes sets beyond retention.</summary>
+        public static Result Create(IEnumerable<string> databases, string backupsDirectory,
+                                    int retention = DefaultRetention,
+                                    Func<DateTimeOffset>? clock = null)
+        {
+            if (databases == null) throw new ArgumentNullException(nameof(databases));
+            if (string.IsNullOrWhiteSpace(backupsDirectory))
+                throw new ArgumentException("A backup directory is required.", nameof(backupsDirectory));
+            if (retention < 1) throw new ArgumentOutOfRangeException(nameof(retention));
+
+            string root = Path.GetFullPath(backupsDirectory);
+            Directory.CreateDirectory(root);
+
+            DateTimeOffset now = (clock ?? (() => DateTimeOffset.UtcNow))().ToUniversalTime();
+            string finalDirectory = UniqueDirectory(root, now.ToString("yyyyMMdd-HHmmss-fff"));
+            string temporaryDirectory = finalDirectory + ".tmp";
+            Directory.CreateDirectory(temporaryDirectory);
+
+            var copied = new List<string>();
+            var manifestFiles = new List<object>();
+            try
+            {
+                foreach (string candidate in databases)
+                {
+                    string source = Path.GetFullPath(candidate);
+                    if (!File.Exists(source)) continue;
+
+                    string fileName = Path.GetFileName(source);
+                    if (copied.Exists(path => string.Equals(Path.GetFileName(path), fileName,
+                                                            StringComparison.OrdinalIgnoreCase)))
+                        throw new InvalidOperationException($"Two databases are named {fileName}.");
+
+                    string destination = Path.Combine(temporaryDirectory, fileName);
+                    BackupOne(source, destination);
+                    if (!Verify(destination, out string check))
+                        throw new InvalidDataException($"{fileName} failed PRAGMA quick_check: {check}");
+
+                    copied.Add(destination);
+                    var info = new FileInfo(source);
+                    manifestFiles.Add(new
+                    {
+                        name = fileName,
+                        bytes = new FileInfo(destination).Length,
+                        sourceLastWriteUtc = info.LastWriteTimeUtc,
+                        quickCheck = check,
+                    });
+                }
+
+                if (copied.Count == 0)
+                    throw new InvalidOperationException("None of the requested databases exists.");
+
+                File.WriteAllText(Path.Combine(temporaryDirectory, "manifest.json"),
+                    JsonSerializer.Serialize(new
+                    {
+                        createdUtc = now,
+                        version = Contract.Version,
+                        files = manifestFiles,
+                    }, new JsonSerializerOptions { WriteIndented = true }));
+
+                Directory.Move(temporaryDirectory, finalDirectory);
+                Rotate(root, retention);
+
+                return new Result
+                {
+                    Directory = finalDirectory,
+                    Files = copied.Select(path => Path.Combine(finalDirectory, Path.GetFileName(path)))
+                                  .ToArray(),
+                };
+            }
+            catch
+            {
+                if (Directory.Exists(temporaryDirectory)) Directory.Delete(temporaryDirectory, true);
+                throw;
+            }
+        }
+
+        public static bool Verify(string database, out string result)
+        {
+            try
+            {
+                var builder = new SqliteConnectionStringBuilder
+                {
+                    DataSource = Path.GetFullPath(database),
+                    Mode = SqliteOpenMode.ReadOnly,
+                    Pooling = false,
+                };
+                using var connection = new SqliteConnection(builder.ToString());
+                connection.Open();
+                using var command = connection.CreateCommand();
+                command.CommandText = "PRAGMA quick_check;";
+                result = Convert.ToString(command.ExecuteScalar()) ?? "no result";
+                return string.Equals(result, "ok", StringComparison.OrdinalIgnoreCase);
+            }
+            catch (Exception ex)
+            {
+                result = ex.Message;
+                return false;
+            }
+        }
+
+        private static void BackupOne(string source, string destination)
+        {
+            var sourceBuilder = new SqliteConnectionStringBuilder
+            {
+                DataSource = source,
+                Mode = SqliteOpenMode.ReadOnly,
+                Pooling = false,
+            };
+            var destinationBuilder = new SqliteConnectionStringBuilder
+            {
+                DataSource = destination,
+                Mode = SqliteOpenMode.ReadWriteCreate,
+                Pooling = false,
+            };
+
+            using var from = new SqliteConnection(sourceBuilder.ToString());
+            using var to = new SqliteConnection(destinationBuilder.ToString());
+            from.Open();
+            to.Open();
+            from.BackupDatabase(to);
+        }
+
+        private static string UniqueDirectory(string root, string stem)
+        {
+            string candidate = Path.Combine(root, stem);
+            int suffix = 1;
+            while (Directory.Exists(candidate) || Directory.Exists(candidate + ".tmp"))
+                candidate = Path.Combine(root, $"{stem}-{suffix++:00}");
+            return candidate;
+        }
+
+        private static void Rotate(string root, int retention)
+        {
+            string normalizedRoot = Path.GetFullPath(root);
+            string prefix = Path.EndsInDirectorySeparator(normalizedRoot)
+                ? normalizedRoot
+                : normalizedRoot + Path.DirectorySeparatorChar;
+            var sets = new DirectoryInfo(root).EnumerateDirectories()
+                .Where(IsBackupSet)
+                .OrderByDescending(directory => directory.Name, StringComparer.Ordinal)
+                .ToList();
+
+            foreach (var stale in sets.Skip(retention))
+            {
+                string target = Path.GetFullPath(stale.FullName);
+                if (!target.StartsWith(prefix, StringComparison.OrdinalIgnoreCase))
+                    throw new InvalidOperationException($"Backup path escaped its root: {target}");
+                Directory.Delete(target, true);
+            }
+        }
+
+        private static bool IsBackupSet(DirectoryInfo directory)
+        {
+            string name = directory.Name;
+            if (name.Length != 19 && name.Length != 22) return false;
+            if (name.Length == 22
+                && (name[19] != '-' || !int.TryParse(name.AsSpan(20, 2), out _))) return false;
+
+            return DateTime.TryParseExact(name.AsSpan(0, 19), "yyyyMMdd-HHmmss-fff",
+                System.Globalization.CultureInfo.InvariantCulture,
+                System.Globalization.DateTimeStyles.None, out _)
+                && File.Exists(Path.Combine(directory.FullName, "manifest.json"));
+        }
+    }
+}

--- a/Jondo.Unity.Server/Managers/DatabaseManager.cs
+++ b/Jondo.Unity.Server/Managers/DatabaseManager.cs
@@ -17,6 +17,7 @@ namespace Jondo.Unity.Server
         public static void Initialize()
         {
             Console.WriteLine("[SQLite] Initializing databases...");
+            DatabaseBackups.CreateBeforeMigration();
 
             // 1. Initialize auth.db
             using (var authConnection = new SqliteConnection(AuthConnectionString))

--- a/Jondo.Unity.Tests/Security/DatabaseBackupsTests.cs
+++ b/Jondo.Unity.Tests/Security/DatabaseBackupsTests.cs
@@ -1,0 +1,156 @@
+using Microsoft.Data.Sqlite;
+using System;
+using System.IO;
+using System.Linq;
+using System.Text.Json;
+using Jondo.Unity.Server;
+using Xunit;
+
+namespace Jondo.Unity.Tests.Security
+{
+    public class DatabaseBackupsTests
+    {
+        [Fact]
+        public void A_backup_set_is_consistent_and_carries_a_manifest()
+        {
+            string root = TemporaryDirectory();
+            try
+            {
+                string auth = CreateDatabase(root, "auth.db", "account");
+                string world = CreateDatabase(root, "world.db", "character");
+                var instant = new DateTimeOffset(2026, 8, 27, 12, 34, 56, 789, TimeSpan.Zero);
+
+                var result = DatabaseBackups.Create(new[] { auth, world },
+                    Path.Combine(root, "backups"), clock: () => instant);
+
+                Assert.Equal("20260827-123456-789", Path.GetFileName(result.Directory));
+                Assert.Equal(2, result.Files.Count);
+                Assert.All(result.Files, file =>
+                {
+                    Assert.True(File.Exists(file));
+                    Assert.True(DatabaseBackups.Verify(file, out string check), check);
+                });
+
+                string manifestPath = Path.Combine(result.Directory, "manifest.json");
+                using var manifest = JsonDocument.Parse(File.ReadAllText(manifestPath));
+                Assert.Equal(2, manifest.RootElement.GetProperty("files").GetArrayLength());
+                Assert.Equal("2026-08-27T12:34:56.789+00:00",
+                             manifest.RootElement.GetProperty("createdUtc").GetString());
+
+                using var restored = new SqliteConnection("Pooling=False;Data Source=" +
+                    Path.Combine(result.Directory, "world.db").Replace('\\', '/'));
+                restored.Open();
+                using var query = restored.CreateCommand();
+                query.CommandText = "SELECT Value FROM Sample;";
+                Assert.Equal("character", query.ExecuteScalar());
+            }
+            finally
+            {
+                Directory.Delete(root, true);
+            }
+        }
+
+        [Fact]
+        public void Rotation_keeps_only_the_newest_complete_sets()
+        {
+            string root = TemporaryDirectory();
+            try
+            {
+                string database = CreateDatabase(root, "world.db", "value");
+                string backups = Path.Combine(root, "backups");
+                string unrelated = Path.Combine(backups, "manual-restore-notes");
+                Directory.CreateDirectory(unrelated);
+                File.WriteAllText(Path.Combine(unrelated, "keep.txt"), "do not rotate this");
+
+                for (int minute = 0; minute < 4; minute++)
+                {
+                    int captured = minute;
+                    DatabaseBackups.Create(new[] { database }, backups, retention: 2,
+                        clock: () => new DateTimeOffset(2026, 8, 27, 12, captured, 0, TimeSpan.Zero));
+                }
+
+                string[] sets = Directory.GetDirectories(backups, "2026*")
+                    .Select(Path.GetFileName).OrderBy(name => name, StringComparer.Ordinal).ToArray()!;
+                Assert.Equal(new[] { "20260827-120200-000", "20260827-120300-000" }, sets);
+                Assert.True(File.Exists(Path.Combine(unrelated, "keep.txt")));
+            }
+            finally
+            {
+                Directory.Delete(root, true);
+            }
+        }
+
+        [Fact]
+        public void Committed_wal_pages_are_present_in_the_snapshot()
+        {
+            string root = TemporaryDirectory();
+            try
+            {
+                string database = Path.Combine(root, "world.db");
+                using (var writer = new SqliteConnection(
+                    "Pooling=False;Data Source=" + database.Replace('\\', '/')))
+                {
+                    writer.Open();
+                    using var command = writer.CreateCommand();
+                    command.CommandText = "PRAGMA journal_mode=WAL; " +
+                                          "CREATE TABLE Sample (Value TEXT NOT NULL); " +
+                                          "INSERT INTO Sample VALUES ('from-wal');";
+                    command.ExecuteNonQuery();
+                    Assert.True(File.Exists(database + "-wal"));
+
+                    var backup = DatabaseBackups.Create(new[] { database },
+                        Path.Combine(root, "backups"));
+                    using var restored = new SqliteConnection("Pooling=False;Data Source=" +
+                        backup.Files.Single().Replace('\\', '/'));
+                    restored.Open();
+                    using var query = restored.CreateCommand();
+                    query.CommandText = "SELECT Value FROM Sample;";
+                    Assert.Equal("from-wal", query.ExecuteScalar());
+                }
+            }
+            finally
+            {
+                Directory.Delete(root, true);
+            }
+        }
+
+        [Fact]
+        public void A_corrupt_source_never_leaves_a_complete_looking_backup()
+        {
+            string root = TemporaryDirectory();
+            try
+            {
+                string corrupt = Path.Combine(root, "world.db");
+                File.WriteAllText(corrupt, "this is not sqlite");
+                string backups = Path.Combine(root, "backups");
+
+                Assert.ThrowsAny<Exception>(() => DatabaseBackups.Create(new[] { corrupt }, backups));
+
+                Assert.Empty(Directory.GetDirectories(backups));
+            }
+            finally
+            {
+                Directory.Delete(root, true);
+            }
+        }
+
+        private static string TemporaryDirectory()
+        {
+            string path = Path.Combine(Path.GetTempPath(), "jondo-backup-tests-" + Guid.NewGuid());
+            Directory.CreateDirectory(path);
+            return path;
+        }
+
+        private static string CreateDatabase(string root, string name, string value)
+        {
+            string path = Path.Combine(root, name);
+            using var connection = new SqliteConnection("Pooling=False;Data Source=" + path.Replace('\\', '/'));
+            connection.Open();
+            using var command = connection.CreateCommand();
+            command.CommandText = "CREATE TABLE Sample (Value TEXT NOT NULL); INSERT INTO Sample VALUES ($value);";
+            command.Parameters.AddWithValue("$value", value);
+            command.ExecuteNonQuery();
+            return path;
+        }
+    }
+}

--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@ Jondo Server.exe              the server; the launcher starts it
 Jondo Studio.exe              the world editor; open it when you want to look or build
 content/                      the only files a person edits by hand, versioned in git
 datos/                        json and bin the emulator reads (maps, items, appearances, zaaps…)
-bases/                        world.db and auth.db, the only things the emulator writes
+bases/                        writable databases and five verified pre-migration backup sets
 docs/                         technical documentation
 launcher_assets/              launcher artwork and music
 JondoFix/                     the MelonLoader mod, source and compiled dll

--- a/docs/README.md
+++ b/docs/README.md
@@ -91,6 +91,11 @@ instead. Three generators that `Paths.cs` still names by hand (`extract_fight_ce
 *Go there* when you need to regenerate a data file, or when you want to know which source a value
 came from before trusting it.
 
+**`database-backups.md`** — Verified snapshots before database migrations.
+How `auth.db` and `world.db` are copied with SQLite's online backup API, checked before publication,
+rotated to five complete sets and restored as a matching pair.
+*Go there* before changing database initialization or recovering an installation after an update.
+
 **`item-commands.md`** — Administrator item creation commands.
 The exact syntax and behavior of `.item` and `.itemset`, including role checks, template and set
 data sources, maximum factory effects, persistence, inventory updates and partial-set failures.

--- a/docs/database-backups.md
+++ b/docs/database-backups.md
@@ -1,0 +1,38 @@
+# Database backups
+
+Before `DatabaseManager.Initialize()` creates tables, alters columns, extracts `world.zip` or runs
+a data migration, the server creates a consistent snapshot of every existing game database.
+
+## Location and contents
+
+Backup sets live under `bases/backups/` in UTC timestamp directories:
+
+```text
+bases/backups/20260827-123456-789/
+  auth.db
+  world.db
+  manifest.json
+```
+
+The SQLite online backup API creates each snapshot, rather than copying the database file directly.
+This matters when a database has committed pages in its WAL file. Every copied database must then
+pass `PRAGMA quick_check`; the manifest records its size, source modification time and result.
+
+The directory is first built with a `.tmp` suffix and renamed only after every database passes.
+A failed or corrupt snapshot is removed and database initialization stops before touching the
+original files.
+
+## Rotation and restore
+
+The five newest complete sets are retained. Older timestamp directories are removed only after a
+new set has been verified and published. Temporary directories never count as valid sets.
+
+To restore while the server is stopped:
+
+1. choose a timestamp directory whose `manifest.json` lists `quickCheck` as `ok`;
+2. keep the current `bases/auth.db` and `bases/world.db` somewhere recoverable;
+3. copy both database files from that same backup set into `bases/`;
+4. start the server and confirm the database initialization log.
+
+Do not mix `auth.db` from one set with `world.db` from another: account and character changes may
+then refer to different points in time.


### PR DESCRIPTION
## Summary
- snapshot authentication and world SQLite databases before opening or migrating them
- use the SQLite backup API so committed WAL data is included
- run quick_check on every copy and publish a backup set only after all databases validate
- write a manifest with timestamp, server version, files and integrity result
- keep the five newest complete sets while leaving unrelated directories untouched
- abort initialization when a safe backup cannot be produced
- document backup location and restoration

## Validation
- 346 tests passed, 0 failed
- tests cover valid manifests, retention, unrelated-directory preservation, committed WAL content and corrupt-source failure without a partial backup