### PR TITLE
Enforce monster spell cast limits

### DIFF
--- a/Jondo.Unity.Server/Handlers/FightHandler.cs
+++ b/Jondo.Unity.Server/Handlers/FightHandler.cs
@@ -3455,6 +3455,17 @@ namespace Jondo.Unity.Server.Handlers
                     var objetivo = ObjetivoDe(fight, monster, spell, monsterGrade, prey, data);
                     if (objetivo == null || !objetivo.IsAlive) break;
 
+                    var rechazo = SpellCastRules.Check(
+                        monster, spell, objetivo.Id, monster.CellId, objetivo.CellId,
+                        data.MaxCastPerTurn, data.MaxCastPerTarget, data.MinCastInterval,
+                        data.CastInLine);
+                    if (rechazo != SpellCastRules.Rejection.None)
+                    {
+                        Program.LogDebug($"[Combate] El monstruo {monster.Id} no lanza el hechizo " +
+                                         $"{spell} sobre {objetivo.Id}: {rechazo}.");
+                        break;
+                    }
+
                     // Y el alcance se mide contra el objetivo ELEGIDO, no contra la presa. Ésa era
                     // la línea que dejaba muertos los hechizos de alcance cero.
                     int lejos = CellDistance(monster.CellId, objetivo.CellId);
@@ -3476,6 +3487,7 @@ namespace Jondo.Unity.Server.Handlers
 
                     monster.CurrentAP -= data.APCost;
                     lanzados++;
+                    SpellCastRules.Register(monster, spell, objetivo.Id, data.MinCastInterval);
 
                     // Y su identificador, para que su lanzamiento también diga QUÉ se lanza.
                     int spellLevel = data.SpellLevelId;
@@ -4106,16 +4118,12 @@ namespace Jondo.Unity.Server.Handlers
             // las lleva bajadas: medido en la captura de Agudeza Absoluta, lanzada en la ronda 8
             // con intervalo 4 —el jxc de ese turno dice 3, el de la 9 dice 2, el de la 10 uno, el
             // de la 11 cero y se relanza en la 12—. Ocho más cuatro, doce.
-            foreach (var hechizo in new List<int>(ending.Recarga.Keys))
-            {
-                if (ending.Recarga[hechizo] > 0) ending.Recarga[hechizo]--;
-            }
+            SpellCastRules.AdvanceCooldowns(ending);
             // Los retos de posicion se juzgan AQUI, con el que acaba todavia donde acabo y con sus
             // PM sin reponer. Va antes de limpiar los contadores del turno, que el Versatil los usa.
             await ChallengeWatcher.TurnEndedAsync(stream, fight, ending);
 
-            ending.LanzadosEsteTurno.Clear();
-            ending.LanzadosPorObjetivo.Clear();
+            SpellCastRules.ClearTurnCounters(ending);
 
             await WriteFrameAsync(stream, ConnectionProtocol.Push(Op.Jto,
                 Network.FightProtocol.BuildSequenceStart(ending.Id,
@@ -4326,6 +4334,7 @@ namespace Jondo.Unity.Server.Handlers
 
             // The turn is over: cancel the timer so it cannot force a second end of turn.
             fight.CancelTurnTimer();
+            SpellCastRules.EndTurn(endingFighter);
 
             var jwkMsg = new ProtoMessage();
             jwkMsg.Fields.Add(new ProtoField { FieldNumber = 3, WireType = 0, VarIntValue = endingFighter.Id });
@@ -5007,7 +5016,10 @@ namespace Jondo.Unity.Server.Handlers
                         BaseDamageMax = sData.BaseDamageMax,
                         Element = sData.Element,
                         NeedsLineOfSight = sData.NeedsLineOfSight,
-                        MaxCastPerTurn = sData.MaxCastPerTurn
+                        CastInLine = sData.CastInLine,
+                        MaxCastPerTurn = sData.MaxCastPerTurn,
+                        MaxCastPerTarget = sData.MaxCastPerTarget,
+                        MinCastInterval = sData.MinCastInterval
                     };
                 },
                 losBlockers

--- a/Jondo.Unity.Server/Managers/DatabaseManager.cs
+++ b/Jondo.Unity.Server/Managers/DatabaseManager.cs
@@ -4090,7 +4090,7 @@ namespace Jondo.Unity.Server
             connection.Open();
 
             var cmd = connection.CreateCommand();
-            cmd.CommandText = "SELECT Id, APCost, MinRange, MaxRange, EffectsJson, CastTestLos, CastInLine, MaxCastPerTurn, MaxCastPerTarget, CriticalHitProbability, CriticalEffectsJson FROM SpellLevels WHERE SpellId = $sid AND Grade = $g LIMIT 1;";
+            cmd.CommandText = "SELECT Id, APCost, MinRange, MaxRange, EffectsJson, CastTestLos, CastInLine, MaxCastPerTurn, MaxCastPerTarget, CriticalHitProbability, CriticalEffectsJson, MinCastInterval FROM SpellLevels WHERE SpellId = $sid AND Grade = $g LIMIT 1;";
             cmd.Parameters.AddWithValue("$sid", spellId);
             cmd.Parameters.AddWithValue("$g", grade);
 
@@ -4119,7 +4119,8 @@ namespace Jondo.Unity.Server
                 CastInLine = !reader.IsDBNull(6) && reader.GetInt32(6) == 1,
                 MaxCastPerTurn = reader.IsDBNull(7) ? 0 : reader.GetInt32(7),
                 MaxCastPerTarget = reader.IsDBNull(8) ? 0 : reader.GetInt32(8),
-                CriticalHitProbability = reader.IsDBNull(9) ? 0 : reader.GetInt32(9)
+                CriticalHitProbability = reader.IsDBNull(9) ? 0 : reader.GetInt32(9),
+                MinCastInterval = reader.IsDBNull(11) ? 0 : reader.GetInt32(11)
             };
 
             // Critical hit damage. It comes in its own effect list: Frozen Arrow does 12-14 water
@@ -4440,6 +4441,9 @@ namespace Jondo.Unity.Server
 
         /// <summary>Casts allowed per turn on the SAME target. 0 = no limit.</summary>
         public int MaxCastPerTarget { get; set; }
+
+        /// <summary>Rounds before the spell can be cast again. 0 = no cooldown.</summary>
+        public int MinCastInterval { get; set; }
 
         /// <summary>
         /// Base critical hit chance, as a percentage. The critical granted by the equipment is

--- a/Jondo.Unity.Tests/Combat/MonsterCastRulesTests.cs
+++ b/Jondo.Unity.Tests/Combat/MonsterCastRulesTests.cs
@@ -1,0 +1,141 @@
+using System.Collections.Generic;
+using Jondo.Unity.World.Fights;
+using Jondo.Unity.World.Maps;
+using Xunit;
+
+namespace Jondo.Unity.Tests.Combat
+{
+    public class MonsterCastRulesTests
+    {
+        private const int SpellId = 42;
+        private const int Origin = 288;
+        private const int AlignedTarget = 317;
+        private const int NonAlignedTarget = 289;
+
+        [Fact]
+        public void A_per_target_limit_blocks_only_the_target_that_spent_it()
+        {
+            var monster = FighterAt(Origin, id: -1, team: 1);
+
+            SpellCastRules.Register(monster, SpellId, targetId: 10, minCastInterval: 0);
+
+            Assert.Equal(
+                SpellCastRules.Rejection.PerTarget,
+                Check(monster, targetId: 10, maxPerTarget: 1));
+            Assert.Equal(
+                SpellCastRules.Rejection.None,
+                Check(monster, targetId: 11, maxPerTarget: 1));
+        }
+
+        [Fact]
+        public void A_minimum_interval_counts_down_at_the_end_of_the_owners_turn()
+        {
+            var monster = FighterAt(Origin, id: -1, team: 1);
+            SpellCastRules.Register(monster, SpellId, targetId: 10, minCastInterval: 4);
+
+            Assert.Equal(SpellCastRules.Rejection.Cooldown, Check(monster, 10, interval: 4));
+
+            SpellCastRules.EndTurn(monster);
+            Assert.Equal(3, monster.Recarga[SpellId]);
+            SpellCastRules.EndTurn(monster);
+            SpellCastRules.EndTurn(monster);
+            SpellCastRules.EndTurn(monster);
+
+            Assert.Equal(0, monster.Recarga[SpellId]);
+            Assert.Equal(SpellCastRules.Rejection.None, Check(monster, 10, interval: 4));
+        }
+
+        [Fact]
+        public void Cast_in_line_uses_the_isometric_axes_not_raw_rows_and_columns()
+        {
+            Assert.True(MapGeometry.AreAligned(Origin, AlignedTarget));
+            Assert.False(MapGeometry.AreAligned(Origin, NonAlignedTarget));
+
+            var monster = FighterAt(Origin, id: -1, team: 1);
+            Assert.Equal(
+                SpellCastRules.Rejection.None,
+                Check(monster, 10, castInLine: true, targetCell: AlignedTarget));
+            Assert.Equal(
+                SpellCastRules.Rejection.NotInLine,
+                Check(monster, 10, castInLine: true, targetCell: NonAlignedTarget));
+        }
+
+        [Fact]
+        public void Monster_ai_does_not_spend_ap_on_a_non_aligned_cast()
+        {
+            var monster = FighterAt(Origin, id: -1, team: 1);
+            var target = FighterAt(NonAlignedTarget, id: 10, team: 0);
+            monster.SpellIds.Add(SpellId);
+
+            var result = MonsterAI.ExecuteTurn(
+                monster,
+                new List<Fighter> { monster, target },
+                spellDataFetcher: _ => Spell(castInLine: true));
+
+            Assert.Equal(0, result.SpellId);
+            Assert.Equal(monster.MaxAP, monster.CurrentAP);
+        }
+
+        [Fact]
+        public void Monster_ai_records_the_target_and_cooldown_of_an_accepted_cast()
+        {
+            var monster = FighterAt(Origin, id: -1, team: 1);
+            var target = FighterAt(AlignedTarget, id: 10, team: 0);
+            monster.SpellIds.Add(SpellId);
+
+            var result = MonsterAI.ExecuteTurn(
+                monster,
+                new List<Fighter> { monster, target },
+                spellDataFetcher: _ => Spell(castInLine: true, interval: 3));
+
+            Assert.Equal(SpellId, result.SpellId);
+            Assert.Equal(1, result.CastCount);
+            Assert.Equal(1, monster.LanzadosEsteTurno[SpellId]);
+            Assert.Equal(1, monster.LanzadosPorObjetivo[(SpellId, target.Id)]);
+            Assert.Equal(3, monster.Recarga[SpellId]);
+        }
+
+        private static SpellCastRules.Rejection Check(
+            Fighter caster,
+            long targetId,
+            int maxPerTarget = 0,
+            int interval = 0,
+            bool castInLine = false,
+            int targetCell = AlignedTarget)
+            => SpellCastRules.Check(
+                caster, SpellId, targetId, caster.CellId, targetCell,
+                maxCastPerTurn: 0, maxPerTarget, interval, castInLine);
+
+        private static MonsterAI.AISpellData Spell(bool castInLine, int interval = 0)
+            => new MonsterAI.AISpellData
+            {
+                SpellId = SpellId,
+                APCost = 2,
+                MinRange = 1,
+                MaxRange = 3,
+                BaseDamageMin = 5,
+                BaseDamageMax = 5,
+                NeedsLineOfSight = false,
+                CastInLine = castInLine,
+                MaxCastPerTurn = 3,
+                MaxCastPerTarget = 1,
+                MinCastInterval = interval
+            };
+
+        private static Fighter FighterAt(int cell, long id, int team)
+            => new Fighter
+            {
+                Id = id,
+                Name = id < 0 ? "Monster" : "Player",
+                TeamId = team,
+                CellId = cell,
+                IsMonster = team == 1,
+                MaxHP = 100,
+                CurrentHP = 100,
+                MaxAP = 6,
+                CurrentAP = 6,
+                MaxMP = 0,
+                CurrentMP = 0
+            };
+    }
+}

--- a/Jondo.Unity.World/Fights/MonsterAI.cs
+++ b/Jondo.Unity.World/Fights/MonsterAI.cs
@@ -44,6 +44,11 @@ namespace Jondo.Unity.World.Fights
             public int BaseDamageMax { get; set; } = 10;
             public int Element { get; set; } = 0;
             public int MaxCastPerTurn { get; set; } = 2;
+            public int MaxCastPerTarget { get; set; }
+            public int MinCastInterval { get; set; }
+
+            /// <summary>Whether the target has to share one of the caster's grid axes.</summary>
+            public bool CastInLine { get; set; }
 
             /// <summary>Whether the spell requires line of sight to the target.</summary>
             public bool NeedsLineOfSight { get; set; } = true;
@@ -214,6 +219,14 @@ namespace Jondo.Unity.World.Fights
             {
                 if (dist >= spell.MinRange && dist <= spell.MaxRange && monster.CurrentAP >= spell.APCost)
                 {
+                    if (SpellCastRules.Check(
+                            monster, spell.SpellId, target.Id, monster.CellId, target.CellId,
+                            spell.MaxCastPerTurn, spell.MaxCastPerTarget, spell.MinCastInterval,
+                            spell.CastInLine) != SpellCastRules.Rejection.None)
+                    {
+                        continue;
+                    }
+
                     // A spell that requires line of sight does not go through walls. This is what
                     // made the piou fire from the far side of the arena's low wall.
                     if (spell.NeedsLineOfSight &&
@@ -243,6 +256,8 @@ namespace Jondo.Unity.World.Fights
 
                     monster.AccumulatedApLoss += spell.APCost;
                     monster.CurrentAP -= spell.APCost;
+                    SpellCastRules.Register(monster, spell.SpellId, target.Id,
+                                            spell.MinCastInterval);
 
                     return (spell.SpellId, damage);
                 }
@@ -272,6 +287,10 @@ namespace Jondo.Unity.World.Fights
                 bool canCastAny = spells.Any(s =>
                     distToTarget >= s.MinRange && distToTarget <= s.MaxRange &&
                     s.APCost <= monster.CurrentAP &&
+                    SpellCastRules.Check(
+                        monster, s.SpellId, target.Id, c, target.CellId,
+                        s.MaxCastPerTurn, s.MaxCastPerTarget, s.MinCastInterval,
+                        s.CastInLine) == SpellCastRules.Rejection.None &&
                     (!s.NeedsLineOfSight || MapGeometry.HasLineOfSight(c, target.CellId, losBlockers)));
 
                 if (canCastAny)

--- a/Jondo.Unity.World/Fights/SpellCastRules.cs
+++ b/Jondo.Unity.World/Fights/SpellCastRules.cs
@@ -1,0 +1,96 @@
+using Jondo.Unity.World.Maps;
+
+namespace Jondo.Unity.World.Fights
+{
+    /// <summary>The stateful cast rules shared by every monster spell execution path.</summary>
+    public static class SpellCastRules
+    {
+        public enum Rejection
+        {
+            None,
+            Cooldown,
+            PerTurn,
+            PerTarget,
+            NotInLine
+        }
+
+        /// <summary>
+        /// Checks the rules which depend on a fighter's cast history. Range, line of sight and AP
+        /// remain the caller's responsibility because they need map and spell-effect data.
+        /// </summary>
+        public static Rejection Check(
+            Fighter caster,
+            int spellId,
+            long targetId,
+            int sourceCell,
+            int targetCell,
+            int maxCastPerTurn,
+            int maxCastPerTarget,
+            int minCastInterval,
+            bool castInLine)
+        {
+            if (minCastInterval > 0 &&
+                caster.Recarga.TryGetValue(spellId, out int cooldown) && cooldown > 0)
+            {
+                return Rejection.Cooldown;
+            }
+
+            caster.LanzadosEsteTurno.TryGetValue(spellId, out int thisTurn);
+            if (maxCastPerTurn > 0 && thisTurn >= maxCastPerTurn)
+                return Rejection.PerTurn;
+
+            caster.LanzadosPorObjetivo.TryGetValue((spellId, targetId), out int onTarget);
+            if (targetId != 0 && maxCastPerTarget > 0 && onTarget >= maxCastPerTarget)
+                return Rejection.PerTarget;
+
+            if (castInLine && !MapGeometry.AreAligned(sourceCell, targetCell))
+                return Rejection.NotInLine;
+
+            return Rejection.None;
+        }
+
+        /// <summary>Records one accepted cast and starts its inter-turn cooldown.</summary>
+        public static void Register(
+            Fighter caster,
+            int spellId,
+            long targetId,
+            int minCastInterval)
+        {
+            caster.LanzadosEsteTurno.TryGetValue(spellId, out int thisTurn);
+            caster.LanzadosEsteTurno[spellId] = thisTurn + 1;
+
+            if (targetId != 0)
+            {
+                caster.LanzadosPorObjetivo.TryGetValue((spellId, targetId), out int onTarget);
+                caster.LanzadosPorObjetivo[(spellId, targetId)] = onTarget + 1;
+            }
+
+            if (minCastInterval > 0) caster.Recarga[spellId] = minCastInterval;
+        }
+
+        /// <summary>
+        /// Advances cooldowns at the end of their owner's turn and clears the two per-turn
+        /// counters. Cooldown keys deliberately remain present when they reach zero, matching the
+        /// protocol's cooldown list.
+        /// </summary>
+        public static void EndTurn(Fighter caster)
+        {
+            AdvanceCooldowns(caster);
+            ClearTurnCounters(caster);
+        }
+
+        public static void AdvanceCooldowns(Fighter caster)
+        {
+            foreach (int spellId in caster.Recarga.Keys.ToArray())
+            {
+                if (caster.Recarga[spellId] > 0) caster.Recarga[spellId]--;
+            }
+        }
+
+        public static void ClearTurnCounters(Fighter caster)
+        {
+            caster.LanzadosEsteTurno.Clear();
+            caster.LanzadosPorObjetivo.Clear();
+        }
+    }
+}

--- a/Jondo.Unity.World/Maps/MapGeometry.cs
+++ b/Jondo.Unity.World/Maps/MapGeometry.cs
@@ -87,6 +87,18 @@ namespace Jondo.Unity.World.Maps
         }
 
         /// <summary>
+        /// Whether two cells share one of the grid's two combat axes. Spells whose
+        /// <c>castInLine</c> flag is set may only be cast between cells for which this returns
+        /// true. The transformed coordinates are important here: comparing raw cell rows or
+        /// columns does not describe a straight line on the isometric board.
+        /// </summary>
+        public static bool AreAligned(int cellA, int cellB)
+        {
+            if (!IsValid(cellA) || !IsValid(cellB)) return false;
+            return PointX[cellA] == PointX[cellB] || PointY[cellA] == PointY[cellB];
+        }
+
+        /// <summary>
         /// Is there line of sight between two cells? Walks the segment joining their centers and
         /// fails if it crosses any cell flagged as opaque. The endpoints do not count: caster and
         /// target never block themselves.

--- a/README.md
+++ b/README.md
@@ -196,7 +196,7 @@ See `docs/jondo-coin.md`.
 - ✅ Loot, victory and defeat screens, experience over **1,889 levels**, level-ups and group respawn
 - ✅ Monster AI: a target chosen **per spell**, range measured against that target, walking to the spell's own range band, `MaxCastPerTurn` honoured, breadth-first pathing around obstacles, and line of sight
 - 🟡 Weapon strikes apply damage and AP cost; the slash animation does not
-- 🟡 `MaxCastPerTarget`, minimum cast interval and cast-in-line are enforced for the player, not for monsters
+- ✅ `MaxCastPerTarget`, minimum cast interval and cast-in-line are enforced for players and monsters
 - ✅ **Push and collision damage** — being shoved into a wall, a hole or another fighter costs health, and the fighter acting as the wall takes half
 - ❌ AP/MP dodge rolls, shields, lock and tackle in melee
 


### PR DESCRIPTION
## Summary
- make monster casts honor MaxCastPerTarget, MinCastInterval and CastInLine
- load the missing minimum interval from SpellLevels
- share cast-history checks, registration and end-of-turn cooldown handling across both monster AI paths
- calculate straight-line casts on the real isometric combat axes
- record accepted monster casts by spell and target and keep zero-valued cooldown entries for protocol synchronization
- mark the corresponding PvM roadmap item complete

## Validation
- 347 tests passed, 0 failed
- regression tests cover per-target isolation, exact cooldown countdown, isometric alignment, rejected AP spending and accepted cast state