### PR TITLE
Implement fixed spell healing

### DIFF
--- a/Jondo.Unity.Server/Handlers/FightHandler.cs
+++ b/Jondo.Unity.Server/Handlers/FightHandler.cs
@@ -776,6 +776,7 @@ namespace Jondo.Unity.Server.Handlers
             Poner(27, sabiduria / PorCadaDiez);   // esquiva de puntos de acción
             Poner(28, sabiduria / PorCadaDiez);   // esquiva de puntos de movimiento
             Poner(12, GameState.StatWisdom);      // sabiduría
+            Poner(49, 0);                         // curas fijas
             Poner(26, 0);                         // invocaciones
             Poner(50, 0);                         // reenvío
             Poner(75, 0);                         // erosión

--- a/Jondo.Unity.Server/Managers/EffectEngine.cs
+++ b/Jondo.Unity.Server/Managers/EffectEngine.cs
@@ -248,8 +248,42 @@ namespace Jondo.Unity.Server.Managers
 
         public static bool VaAlSuelo(int efecto) => AlSuelo.Contains(efecto);
 
+        /// <summary>"Cura: #1 a #2". La inteligencia multiplica la base y la 49 se suma al final.</summary>
+        private const int CuraFija = EffectSupport.Heal;
+
+        /// <summary>La característica de Inteligencia, que multiplica las curas fijas.</summary>
+        private const int Inteligencia = 15;
+
+        /// <summary>La característica 49, «Curas»: puntos planos añadidos después de la Inteligencia.</summary>
+        private const int Curas = 49;
+
+        /// <summary>El efecto 1159, «Curas recibidas x#1%».</summary>
+        private const int CurasRecibidasPorCiento = 1159;
+
         /// <summary>"Cura: #1% de los PdV máximos". El dado es el porcentaje.</summary>
         private const int CuraPorcentual = EffectSupport.HealPercent;
+
+        /// <summary>
+        /// Convierte la tirada de un efecto 108 en puntos de vida.
+        ///
+        ///   cura = base × (100 + inteligencia) / 100 + curas fijas
+        ///
+        /// La potencia y los daños no intervienen. El multiplicador de curas recibidas va al final,
+        /// igual que el multiplicador de daños sufridos en la fórmula de daño.
+        /// </summary>
+        public static int CalcularCuraFija(int curaBase, int inteligencia, int curasFijas,
+                                          int multiplicadorRecibido = 100)
+        {
+            if (curaBase <= 0 || multiplicadorRecibido <= 0) return 0;
+
+            long porcentaje = Math.Max(0L, 100L + inteligencia);
+            long calculada = (long)curaBase * porcentaje / 100L + curasFijas;
+            if (calculada <= 0) return 0;
+
+            double multiplicada = calculada * (multiplicadorRecibido / 100.0);
+            if (multiplicada >= int.MaxValue) return int.MaxValue;
+            return Math.Max(0, (int)Math.Round(multiplicada));
+        }
 
         /// <summary>Los dos números de característica de los puntos.</summary>
         /// <summary>
@@ -334,6 +368,13 @@ namespace Jondo.Unity.Server.Managers
                 }
                 if (!leToca) continue;
 
+                // Igual que el daño, una cura con zona tira el dado una sola vez por lanzamiento.
+                // Todos los destinatarios parten del mismo número y sólo cambia la caída por su
+                // distancia al centro.
+                int tiradaCompartida = efecto.EffectId == CuraFija || efecto.EffectId == CuraPorcentual
+                    ? DelDado(efecto.DiceNum, efecto.DiceSide, efecto.Value)
+                    : int.MinValue;
+
                 // Lo que se pone EN EL SUELO no busca a nadie: va a la casilla, esté quien esté.
                 //
                 // Aquí se caían las balizas. El efecto 181 lleva máscara "a,A" y zona de punto, y
@@ -344,7 +385,7 @@ namespace Jondo.Unity.Server.Managers
                 if (VaAlSuelo(efecto.EffectId))
                 {
                     var puesta = Aplicar(combate, quienLanza, quienLanza, hechizo, grado, efecto,
-                                         ronda, celdaApuntada);
+                                         ronda, celdaApuntada, tiradaCompartida);
                     if (puesta != null) fuera.Add(puesta);
                     continue;
                 }
@@ -358,7 +399,7 @@ namespace Jondo.Unity.Server.Managers
                 foreach (var sobre in AQuien(combate, quienLanza, objetivo, efecto, celdaApuntada))
                 {
                     var hecho = Aplicar(combate, quienLanza, sobre, hechizo, grado, efecto, ronda,
-                                        celdaApuntada);
+                                        celdaApuntada, tiradaCompartida);
                     if (unaSolaVez)
                     {
                         if (hecho != null) fuera.Add(hecho);
@@ -529,7 +570,7 @@ namespace Jondo.Unity.Server.Managers
 
         private static Outcome Aplicar(FightInstance combate, Fighter quienLanza, Fighter sobre,
                                             int hechizo, int grado, SpellEffect efecto, int ronda,
-                                            int celdaApuntada = -1)
+                                            int celdaApuntada = -1, int tiradaCompartida = int.MinValue)
         {
             // El daño lo lleva quien ya lo llevaba; aquí no se toca.
             if (efecto.EffectId >= DanoPrimero && efecto.EffectId <= DanoUltimo) return null;
@@ -783,15 +824,60 @@ namespace Jondo.Unity.Server.Managers
                 };
             }
 
+            // Las curaciones fijas. La tirada es una sola para toda la zona; después se aplica la
+            // caída de la casilla, la Inteligencia, las curas planas y lo que multiplique las curas
+            // recibidas por el objetivo. No intervienen ni la potencia ni los daños.
+            if (efecto.EffectId == CuraFija)
+            {
+                int curaBase = tiradaCompartida != int.MinValue
+                    ? tiradaCompartida
+                    : DelDado(efecto.DiceNum, efecto.DiceSide, efecto.Value);
+                if (curaBase <= 0) return null;
+
+                int lejos = celdaApuntada >= 0
+                    ? Jondo.Unity.World.Maps.MapGeometry.Distance(celdaApuntada, sobre.CellId)
+                    : 0;
+                curaBase = ConLaCaidaDeLaZona(curaBase, efecto, lejos);
+
+                int inteligencia = quienLanza.Intelligence + quienLanza.Buffs.De(Inteligencia, ronda);
+                int curasFijas = quienLanza.Otra(Curas) + quienLanza.Buffs.De(Curas, ronda);
+                int multiplicador = sobre.Buffs.Multiplicador(CurasRecibidasPorCiento, ronda);
+                int puntos = CalcularCuraFija(curaBase, inteligencia, curasFijas, multiplicador);
+                puntos = Math.Min(puntos, Math.Max(0, sobre.MaxHP - sobre.CurrentHP));
+                if (puntos <= 0) return null;
+
+                sobre.CurrentHP += puntos;
+                return new Outcome
+                {
+                    Sobre = sobre, Efecto = efecto,
+                    HechizoOrigen = hechizo, NivelOrigen = grado,
+                    Cura = puntos,
+                };
+            }
+
             // Las curaciones por tanto por ciento de la vida máxima. El dado es el PORCENTAJE, no
             // los puntos: la Baliza de Supervivencia cura un siete por ciento del tope de quien
-            // recibe, y en el cable eso viaja ya resuelto en puntos.
+            // recibe, y en el cable eso viaja ya resuelto en puntos. No reciben Inteligencia ni
+            // curas fijas, pero sí la caída de zona y los multiplicadores de curas recibidas.
             if (efecto.EffectId == CuraPorcentual)
             {
-                int cuanto = efecto.DiceNum != 0 ? efecto.DiceNum : efecto.Value;
+                int cuanto = tiradaCompartida != int.MinValue
+                    ? tiradaCompartida
+                    : DelDado(efecto.DiceNum, efecto.DiceSide, efecto.Value);
                 if (cuanto <= 0) return null;
 
-                int puntos = Math.Max(1, sobre.MaxHP * cuanto / 100);
+                int lejos = celdaApuntada >= 0
+                    ? Jondo.Unity.World.Maps.MapGeometry.Distance(celdaApuntada, sobre.CellId)
+                    : 0;
+                cuanto = ConLaCaidaDeLaZona(cuanto, efecto, lejos);
+                if (cuanto <= 0) return null;
+
+                long porVida = Math.Max(1L, (long)sobre.MaxHP * cuanto / 100L);
+                int multiplicador = sobre.Buffs.Multiplicador(CurasRecibidasPorCiento, ronda);
+                double multiplicada = porVida * (Math.Max(0, multiplicador) / 100.0);
+                int puntos = multiplicada >= int.MaxValue
+                    ? int.MaxValue
+                    : Math.Max(0, (int)Math.Round(multiplicada));
                 puntos = Math.Min(puntos, Math.Max(0, sobre.MaxHP - sobre.CurrentHP));
                 if (puntos <= 0) return null;
 

--- a/Jondo.Unity.Tests/Combat/EffectSupportTests.cs
+++ b/Jondo.Unity.Tests/Combat/EffectSupportTests.cs
@@ -12,22 +12,21 @@ namespace Jondo.Unity.Tests.Combat
     /// <see cref="EffectSupport"/>, so an effect gaining an implementation without being added here
     /// would not compile.
     ///
-    /// Measured over the 872 effects in <c>world.db</c>: 20 have code, 205 are applied as a
-    /// characteristic, and <b>647 do nothing at all</b> — and 15,841 of the 34,823 spell levels
-    /// carry at least one of those 647.
+    /// Effect 108 is also kept here explicitly because its catalogue row alone cannot reveal that
+    /// the engine now knows how to heal.
     /// </remarks>
     public class EffectSupportTests
     {
         /// <summary>
-        /// Effect 108 is healing, and it does nothing. The card says it heals, the animation plays,
-        /// and nobody's life goes up. It is on 751 spell levels.
+        /// Effect 108 has no characteristic and belongs to category 2, but direct support wins over
+        /// both catalogue fields. It occurs on 751 spell levels.
         /// </summary>
         [Fact]
-        public void Healing_is_still_not_implemented_and_says_so()
+        public void Fixed_healing_is_implemented_despite_its_catalogue_row()
         {
-            // Its catalogue row carries no characteristic, which is exactly why it falls through.
-            Assert.Equal(EffectSupportKind.PanelOnly, EffectSupport.Classify(108, 0, 2));
-            Assert.DoesNotContain(108, EffectSupport.HandledDirectly);
+            Assert.Equal(EffectSupportKind.Direct,
+                         EffectSupport.Classify(EffectSupport.Heal, 0, 2));
+            Assert.Contains(EffectSupport.Heal, EffectSupport.HandledDirectly);
         }
 
         [Theory]
@@ -39,6 +38,7 @@ namespace Jondo.Unity.Tests.Combat
         [InlineData(EffectSupport.RemoveState)]
         [InlineData(EffectSupport.CastSpell)]
         [InlineData(EffectSupport.Summon)]
+        [InlineData(EffectSupport.Heal)]
         [InlineData(EffectSupport.HealPercent)]
         [InlineData(EffectSupport.Kill)]
         public void The_effects_with_code_are_reported_as_such(int effectId)

--- a/Jondo.Unity.Tests/Combat/HealingTests.cs
+++ b/Jondo.Unity.Tests/Combat/HealingTests.cs
@@ -1,0 +1,44 @@
+using Jondo.Unity.Server.Managers;
+using Xunit;
+
+namespace Jondo.Unity.Tests.Combat
+{
+    public class HealingTests
+    {
+        [Theory]
+        [InlineData(20, 0, 0, 20)]
+        [InlineData(20, 200, 0, 60)]
+        [InlineData(20, 200, 7, 67)]
+        [InlineData(21, 50, 0, 31)]
+        public void Fixed_healing_uses_intelligence_then_flat_heals(
+            int baseHeal, int intelligence, int flatHeals, int expected)
+            => Assert.Equal(expected,
+                            EffectEngine.CalcularCuraFija(baseHeal, intelligence, flatHeals));
+
+        [Theory]
+        [InlineData(40, 0, 0, 50, 20)]
+        [InlineData(40, 0, 0, 110, 44)]
+        [InlineData(40, 0, 0, 0, 0)]
+        public void Received_healing_multiplier_is_applied_last(
+            int baseHeal, int intelligence, int flatHeals, int multiplier, int expected)
+            => Assert.Equal(expected,
+                            EffectEngine.CalcularCuraFija(
+                                baseHeal, intelligence, flatHeals, multiplier));
+
+        [Theory]
+        [InlineData(20, -100, 5, 5)]
+        [InlineData(20, -200, 0, 0)]
+        [InlineData(20, 0, -25, 0)]
+        [InlineData(0, 500, 500, 0)]
+        public void Fixed_healing_never_becomes_negative(
+            int baseHeal, int intelligence, int flatHeals, int expected)
+            => Assert.Equal(expected,
+                            EffectEngine.CalcularCuraFija(baseHeal, intelligence, flatHeals));
+
+        [Fact]
+        public void Fixed_healing_saturates_instead_of_overflowing()
+            => Assert.Equal(int.MaxValue,
+                            EffectEngine.CalcularCuraFija(
+                                int.MaxValue, int.MaxValue, int.MaxValue, int.MaxValue));
+    }
+}

--- a/Jondo.Unity.World/Combat/EffectSupport.cs
+++ b/Jondo.Unity.World/Combat/EffectSupport.cs
@@ -26,10 +26,9 @@ namespace Jondo.Unity.World.Combat
     /// </summary>
     /// <remarks>
     /// This is the information the architecture document calls the most useful thing in the whole
-    /// spell module, and the reason is effect 108 — healing. Its catalogue row carries no
-    /// characteristic, so it falls through to the panel-only branch: the spell card says the spell
-    /// heals, the animation plays, and nobody's life goes up. Nothing anywhere says so, and until
-    /// now the only way to know was to read <c>EffectEngine.cs</c>.
+    /// spell module. Effect 108 — healing — is the reason this list matters: its catalogue row
+    /// carries no characteristic, so it used to fall through to the panel-only branch even though
+    /// the spell card said that it healed. Keeping it here makes the implementation explicit.
     ///
     /// There are two ways an effect can work, and they are not the same:
     ///
@@ -72,6 +71,9 @@ namespace Jondo.Unity.World.Combat
         /// <summary>Summon a creature.</summary>
         public const int Summon = 181;
 
+        /// <summary>Heal a fixed amount, scaled by Intelligence and the Heals characteristic.</summary>
+        public const int Heal = 108;
+
         /// <summary>Heal a percentage of maximum life.</summary>
         public const int HealPercent = 1109;
 
@@ -103,7 +105,7 @@ namespace Jondo.Unity.World.Combat
             {
                 Push, Pull, StepBack, StepForward,
                 AddState, RemoveState,
-                CastSpell, Summon, HealPercent, Kill,
+                CastSpell, Summon, Heal, HealPercent, Kill,
             };
 
             for (int damage = FirstDamage; damage <= LastDamage; damage++) known.Add(damage);

--- a/README.md
+++ b/README.md
@@ -218,7 +218,7 @@ One engine for all eighteen classes, driven entirely by client data. Not a singl
 - ✅ Summons as real fighters — own sheet, place in the carousel next to their owner, behaviour spell, lifetime, and they all fall when their summoner dies
 - ✅ Item attitudes — the six Dofus and the trophies grant their spell through effect 1175
 - ✅ The characteristic sheet in the shape the client expects: 53 entries in a fixed order, and a single-characteristic refresh **replaces** its entry rather than adding to it, so it repeats every field and puts the buff in its own slot `f8`
-- ❌ Healing — effect 108 is not wired; its catalogue row has `Characteristic = 0` and `Category = 2`, so it falls into the panel-only branch
+- ✅ Healing — effect 108 rolls once per cast, applies area falloff, Intelligence, flat Heals and received-healing multipliers, then caps the result to the target's missing life
 - ❌ Glyphs and traps (effects 400, 401, 1091)
 - ❌ Appearance-changing spells — the transform payload is an opaque blob, so the Cra's Sentinel works but does not change its look
 - ❌ Area shapes `G` (55 effects) and `*` (10), which fall back to the centre tile alone
@@ -361,11 +361,11 @@ is wrong. Four things it found, all measured:
   across 401 captures, 184 shows up on 420 elements and 114 on 23, every one a zaap. Our own log
   catches us emitting the pair `(type 0, skill 114)` 84 times — a pair that occurs zero times
   anywhere real. New passages declare 184
-- **647 of the game's 872 effects do nothing at all.** They are drawn on the spell card and the
-  engine has no code for them and no characteristic to apply — and **15,841 of the 34,823 spell
-  levels carry at least one**. The Studio ranks them by how many levels each one breaks, which turns
-  a curiosity into a work list: effect 1160 alone is on 6,709 levels, and healing — effect 108 — is
-  on 751
+- **The first audit found 647 of the game's 872 effects doing nothing at all.** They were drawn on
+  the spell card but had neither direct code nor a characteristic to apply, and **15,841 of the
+  34,823 spell levels carried at least one**. The Studio ranks them by how many levels each one
+  breaks, which turns a curiosity into a work list: effect 1160 alone is on 6,709 levels. Healing —
+  effect 108 — was one of those priorities with 751 levels and is now handled directly
 - **A monster's picture is filed under its `gfxId`, not its id.** Keyed by id, 847 of 5,134 found a
   picture and every one of those 847 was *somebody else's* creature. Keyed by gfxId it is 5,130
 

--- a/docs/world-editor.md
+++ b/docs/world-editor.md
@@ -261,9 +261,9 @@ motor que no tiene ni un hechizo escrito a mano: todo sale de los datos.
 
 **Falta.** Editar el `EffectsJson` con una interfaz en vez de a mano, y —lo realmente útil— una
 vista que diga **qué efectos sabe aplicar el motor y cuáles caen en la rama de «sólo para el
-panel»**. Hoy eso sólo se sabe leyendo `EffectEngine.cs`, y es la información que decide si un
-hechizo funciona de verdad. El efecto 108, la curación, es el ejemplo: parece que funciona y no cura
-a nadie.
+panel»**. La clasificación compartida de `EffectSupport` evita tener que deducirlo leyendo
+`EffectEngine.cs`. El efecto 108, la curación, fue el primer caso importante: el catálogo parecía
+válido pero no bastaba para aplicarlo, así que ahora figura como efecto directo.
 
 Un simulador —lanzar un hechizo contra un objetivo de prueba y ver las consecuencias sin montar un
 combate— vale más que el propio editor.


### PR DESCRIPTION
## Summary
- resolve effect 108 as fixed spell healing instead of a panel-only buff
- apply one shared area roll, zone falloff, Intelligence, flat Heals and received-healing modifiers
- report fixed healing as directly supported and add focused regression coverage
- document the supported healing behavior

## Validation
- 355 tests passed, 0 failed
- validated in game: spell healing restores the expected life instead of triggering passive full healing