### PR TITLE
Handle fight abandonment

### DIFF
--- a/Jondo.Unity.Server/Handlers/FightHandler.cs
+++ b/Jondo.Unity.Server/Handlers/FightHandler.cs
@@ -1206,6 +1206,13 @@ namespace Jondo.Unity.Server.Handlers
                 // Pasar turno. Va vacío.
                 await PassTurnAsync(stream);
             }
+            else if (payloadStr.Contains("type.ankama.com/kme"))
+            {
+                // Abandonar. El cliente de la 3.6.10.10 manda un kme vacío al confirmar el
+                // diálogo. Hasta ahora ni siquiera atravesaba la puerta de GameNodeProxy y
+                // acababa registrado como paquete sin atender, por lo que el botón no hacía nada.
+                await AbandonAsync(stream);
+            }
             else if (payloadStr.Contains(Op.Uri(Op.Jrw)))
             {
                 // Andar. Es el mismo mensaje que fuera del combate; aquí gasta PM.
@@ -3795,6 +3802,26 @@ namespace Jondo.Unity.Server.Handlers
 
             await EndFightAsync(stream, fight);
             return true;
+        }
+
+        /// <summary>
+        /// Fuerza la derrota del bando del jugador y termina el combate sin recompensa.
+        ///
+        /// Se tumban también sus invocaciones: dejar una viva haría que EndFightAsync viera aún
+        /// un aliado con vida y convirtiera el abandono en victoria. Al ser una derrota, el grupo
+        /// de monstruos no se elimina ni se repone y se puede volver a atacar después.
+        /// </summary>
+        private static async Task AbandonAsync(NetworkStream stream)
+        {
+            var fight = GetCurrentFight();
+            if (fight == null) return;
+
+            fight.FinPendiente = 0;
+            foreach (var ally in fight.Team0) ally.CurrentHP = 0;
+
+            Program.LogDebug($"[Combate] {GameState.CharacterId} abandona el combate " +
+                             $"#{fight.FightId}: derrota sin recompensa.");
+            await EndFightAsync(stream, fight);
         }
 
         /// <summary>Lo que se manda cuando el combate se acaba de verdad.</summary>

--- a/Jondo.Unity.Server/Network/GameNodeProxy.cs
+++ b/Jondo.Unity.Server/Network/GameNodeProxy.cs
@@ -832,6 +832,7 @@ namespace Jondo.Unity.Server.Network
                 }
                 else if (payloadStr.Contains(Op.Uri(Op.Jzy)) || payloadStr.Contains(Op.Uri(Op.Kaq))
                          || payloadStr.Contains("type.ankama.com/jwz") || payloadStr.Contains("type.ankama.com/jxy")
+                         || payloadStr.Contains("type.ankama.com/kme")
                          || payloadStr.Contains(Op.Uri(Op.Jwh))
                          || payloadStr.Contains(Op.Uri(Op.Jwn))
                          || payloadStr.Contains(Op.Uri(Op.Jti))
@@ -840,7 +841,7 @@ namespace Jondo.Unity.Server.Network
                          || payloadStr.Contains(Op.Uri(Op.Kwv)) || payloadStr.Contains(Op.Uri(Op.Kwi))
                          || payloadStr.Contains(Op.Uri(Op.Kwo)) || payloadStr.Contains(Op.Uri(Op.Kxb)))
                 {
-                    // Colocarse, declararse listo, las opciones del combate y los RETOS. Los demás
+                    // Colocarse, declararse listo, abandonar, las opciones del combate y los RETOS. Los demás
                     // que había aquí —jxx, jyk, jyz, jza, jwe, jrb, jub, jxw— o no existen en la
                     // 3.6.10.10 o los manda el servidor, no el cliente.
                     //


### PR DESCRIPTION
## Summary
- handle the client kme request instead of leaving the player trapped in combat
- finish abandonment as a defeat without rewards
- keep the monster group available and return the character to the surface map

## Validation
- 342 tests passed, 0 failed
- validated in game: abandoning closes the fight and returns the player to the map