### PR TITLE
Fix summon availability and NPC dialog closing

### DIFF
--- a/Jondo.Unity.Server/Handlers/FightHandler.cs
+++ b/Jondo.Unity.Server/Handlers/FightHandler.cs
@@ -776,7 +776,10 @@ namespace Jondo.Unity.Server.Handlers
             Poner(27, sabiduria / PorCadaDiez);   // esquiva de puntos de acción
             Poner(28, sabiduria / PorCadaDiez);   // esquiva de puntos de movimiento
             Poner(12, GameState.StatWisdom);      // sabiduría
-            Poner(26, 0);                         // invocaciones
+            // Todo personaje puede llevar una invocación de base. Mandar cero no sólo pintaba
+            // mal el panel: el cliente usa este mismo total para habilitar los hechizos de
+            // invocación, por eso Dragún aparecía gris aunque el servidor lo hubiese aceptado.
+            Poner(26, 1);                         // invocaciones
             Poner(50, 0);                         // reenvío
             Poner(75, 0);                         // erosión
             Poner(101, 0);                        // % de resistencia a los daños
@@ -2468,13 +2471,19 @@ namespace Jondo.Unity.Server.Handlers
         /// </summary>
         private static int TopeDeInvocaciones(Fighter quien, int ronda)
         {
+            // RellenarLaFicha ya metió el equipo en Otras. Volver a sumarlo aquí duplicaba cada
+            // +invocación de los objetos: el cliente veía un total y el límite del servidor era
+            // otro. La ficha es la fuente única, tanto para jugadores como para monstruos.
             int suyo = quien.Otra(CaracteristicaDeInvocaciones);
-            if (!quien.IsMonster)
-            {
-                suyo += StatsHandler.GetEquipBonus(CaracteristicaDeInvocaciones);
-            }
             return Math.Max(0, suyo + quien.Buffs.De(CaracteristicaDeInvocaciones, ronda));
         }
+
+        /// <summary>Guardia de regresión: monta las características que recibe un jugador.</summary>
+        internal static void RellenarFichaParaLaGuardia(Fighter quien) => RellenarLaFicha(quien);
+
+        /// <summary>Guardia de regresión: el mismo límite que aplica una invocación real.</summary>
+        internal static int TopeDeInvocacionesParaLaGuardia(Fighter quien, int ronda)
+            => TopeDeInvocaciones(quien, ronda);
 
         /// <summary>Las que tiene ahora mismo en el tablero.</summary>
         private static int CuantasLleva(FightInstance fight, Fighter quien)

--- a/Jondo.Unity.Server/Handlers/NpcHandler.cs
+++ b/Jondo.Unity.Server/Handlers/NpcHandler.cs
@@ -57,6 +57,9 @@ namespace Jondo.Unity.Server.Handlers
 
         public static bool IsShopOpen => OpenShop != 0;
 
+        /// <summary>Si el jugador está hablando ahora mismo con un NPC.</summary>
+        public static bool IsDialogueOpen => SessionContext.State.OpenDialogueNpcId != 0;
+
         /// <summary>
         /// Desde dónde se numeran los objetos comprados.
         ///
@@ -225,6 +228,19 @@ namespace Jondo.Unity.Server.Handlers
             SessionContext.State.OpenDialogueNpcId = 0;
             SessionContext.State.OpenDialogueMapId = 0;
             SessionContext.State.OpenDialogueMessage = 0;
+        }
+
+        /// <summary>
+        /// El jugador ha pulsado la cruz del diálogo (kla). La conversación de NPC se cierra con
+        /// razón 1; la razón 10 pertenece al zaap y el cliente no la aplica a esta ventana.
+        /// </summary>
+        public static async Task CloseDialogueAsync(NetworkStream stream)
+        {
+            CerrarConversacion();
+            await Jondo.Protocol.NetworkMessage.WriteFrameAsync(stream,
+                ConnectionProtocol.Push(Op.Kld, ConnectionProtocol.BuildDialogClosed(
+                    ConnectionProtocol.NpcDialogCloseReason)));
+            Console.WriteLine("[NPC] Diálogo cerrado por el jugador.");
         }
 
         /// <summary>
@@ -521,6 +537,7 @@ namespace Jondo.Unity.Server.Handlers
         {
             OpenShop = 0;
             OpenShopNpc = 0;
+            CerrarConversacion();
         }
 
         /// <summary>

--- a/Jondo.Unity.Server/Network/GameNodeProxy.cs
+++ b/Jondo.Unity.Server/Network/GameNodeProxy.cs
@@ -591,7 +591,8 @@ namespace Jondo.Unity.Server.Network
                 else if (payloadStr.Contains("type.ankama.com/kla"))
                 {
                     // El botón de cerrar del diálogo. Va vacío y espera respuesta: khd si lo que
-                    // está abierto es el cofre o la tienda de un NPC, kld si es la lista del zaap.
+                    // está abierto es el cofre o la tienda de un NPC; kld con razón 1 si es una
+                    // conversación de NPC, y kld con razón 10 si es la lista del zaap.
                     //
                     // El cliente manda el kla DOS veces seguidas al cerrar una tienda, con menos de
                     // un milisegundo entre medias, y el servidor real contesta un solo khd. Como el
@@ -599,6 +600,7 @@ namespace Jondo.Unity.Server.Network
                     // kld que el cliente ignora, igual que hoy.
                     if (ChestHandler.IsOpen) await ChestHandler.CloseAsync(stream);
                     else if (NpcHandler.IsShopOpen) await NpcHandler.CloseShopAsync(stream);
+                    else if (NpcHandler.IsDialogueOpen) await NpcHandler.CloseDialogueAsync(stream);
                     else await ZaapTravelHandler.CloseAsync(stream);
                 }
                 else if (payloadStr.Contains(Op.Uri(Op.Hjc)))

--- a/Jondo.Unity.Tests/Combat/FightSheetTests.cs
+++ b/Jondo.Unity.Tests/Combat/FightSheetTests.cs
@@ -1,5 +1,6 @@
 ﻿using System.Linq;
 using Jondo.Unity.Server.Handlers;
+using Jondo.Unity.Server.Network;
 using Jondo.Unity.World.Fights;
 using Xunit;
 
@@ -80,6 +81,26 @@ namespace Jondo.Unity.Tests.Combat
             {
                 var entry = sheet.Find(e => e.Characteristic == which);
                 Assert.Equal(100, entry.Base);
+            }
+        }
+
+        [Fact]
+        public void A_player_has_one_base_summon_and_the_sheet_total_is_the_limit()
+        {
+            var session = GameSession.SinSocket();
+            using (SessionContext.Push(session))
+            {
+                var fighter = new Fighter();
+
+                FightHandler.RellenarFichaParaLaGuardia(fighter);
+
+                var summon = FightHandler.FichaParaLaGuardia(fighter)
+                                         .Find(e => e.Characteristic == 26);
+                Assert.Equal(1, summon.Base + summon.Gear);
+
+                // Otras already is the complete sheet total (base + equipment).
+                fighter.Otras[26] = 3;
+                Assert.Equal(3, FightHandler.TopeDeInvocacionesParaLaGuardia(fighter, 1));
             }
         }
     }

--- a/Jondo.Unity.Tests/Sessions/SessionIsolationTests.cs
+++ b/Jondo.Unity.Tests/Sessions/SessionIsolationTests.cs
@@ -2,6 +2,7 @@
 using System.IO;
 using System.Threading;
 using System.Threading.Tasks;
+using Jondo.Unity.Server.Handlers;
 using Jondo.Unity.Server.Managers;
 using Jondo.Unity.Server.Network;
 using Xunit;
@@ -79,6 +80,26 @@ namespace Jondo.Unity.Tests.Sessions
                 Assert.Equal(2002, SpellChoices.Chosen[1]);
                 Assert.Equal(2002, SpellChoices.Bar[0]);
                 Assert.Equal(22, second.State.OpenNpcShopId);
+            }
+        }
+
+        [Fact]
+        public void Forgetting_an_npc_window_also_clears_its_dialogue()
+        {
+            var session = GameSession.SinSocket();
+            session.State.OpenDialogueNpcId = 4369;
+            session.State.OpenDialogueMapId = 153092354;
+            session.State.OpenDialogueMessage = 30424;
+
+            using (SessionContext.Push(session))
+            {
+                Assert.True(NpcHandler.IsDialogueOpen);
+
+                NpcHandler.Forget();
+
+                Assert.False(NpcHandler.IsDialogueOpen);
+                Assert.Equal(0, session.State.OpenDialogueMapId);
+                Assert.Equal(0, session.State.OpenDialogueMessage);
             }
         }
 


### PR DESCRIPTION
## Summary
- give every character one base summon in the fight sheet so summon spells are not disabled at zero
- use the complete sheet total as the server summon limit
- handle kla while an NPC conversation is open and answer with kld reason 1
- clear NPC dialogue state when the window is closed or forgotten

## Validation
- 344 tests passed, 0 failed
- validated in game: summon spells are enabled and the NPC dialogue close button dismisses the window