### PR TITLE
Make active summons and Osamodas Gobgob functional

### DIFF
--- a/Jondo.Unity.Server/Guards/RegressionGuardTests.cs
+++ b/Jondo.Unity.Server/Guards/RegressionGuardTests.cs
@@ -544,6 +544,9 @@ namespace Jondo.Unity.Server
                 // cancelaba estos tres.
                 (2854, 0, new[] { 2230, 2231, 2355 }, "Jalamut Real"),
                 (2894, 0, new[] { 2366, 2367, 2368 }, "Rata kenopintamos"),
+                // Un invocado activo: startingSpellId vale cero y TODO su turno depende de que
+                // se lean estos dos desde MonsterTemplates.spells.
+                (8076, 2, new[] { 31166, 31168 }, "Dragoune"),
             };
 
             foreach (var (monstruo, grado, hechizos, quien) in esperado)

--- a/Jondo.Unity.Server/Handlers/FightHandler.cs
+++ b/Jondo.Unity.Server/Handlers/FightHandler.cs
@@ -2707,6 +2707,17 @@ namespace Jondo.Unity.Server.Handlers
                     }
                 }
 
+                if (c.HechizoConRecarga > 0 && c.TurnosDeRecarga > 0)
+                {
+                    c.Sobre.Recarga[c.HechizoConRecarga] = c.TurnosDeRecarga;
+                    await WriteFrameAsync(stream, ConnectionProtocol.Push(Op.Jxc,
+                        Network.FightProtocol.BuildCooldowns(c.Sobre.Id, RecargasDe(c.Sobre))));
+                    Program.LogDebug($"[Combate] El efecto {c.Efecto.EffectId} fija la recarga de " +
+                                     $"{c.HechizoConRecarga} a {c.TurnosDeRecarga} ronda(s) " +
+                                     $"sobre {c.Sobre.Id}.");
+                    continue;
+                }
+
                 // Las curaciones.
                 if (c.Cura > 0)
                 {
@@ -3127,6 +3138,20 @@ namespace Jondo.Unity.Server.Handlers
                 Program.LogDebug($"[Combate] El efecto {efecto.EffectId} pega el {sacadoDelDado}% de " +
                                  $"los {target.VidaErosionada} erosionados de {target.Id}: {baseDamage}.");
             }
+            else if (efecto.EffectId == EffectSupport.CasterCurrentHealthDamage)
+            {
+                baseDamage = caster.CurrentHP * sacadoDelDado / 100;
+                Program.LogDebug($"[Combate] El efecto {efecto.EffectId} pega el {sacadoDelDado}% " +
+                                 $"de la vida actual de {caster.Id}: {baseDamage}.");
+            }
+            else if (efecto.EffectId == EffectSupport.CasterMissingHealthDamage)
+            {
+                int missing = Math.Max(0, caster.MaxHP - caster.CurrentHP);
+                baseDamage = missing * sacadoDelDado / 100;
+                Program.LogDebug($"[Combate] El efecto {efecto.EffectId} pega el {sacadoDelDado}% " +
+                                 $"de los {missing} puntos de vida que le faltan a {caster.Id}: " +
+                                 $"{baseDamage}.");
+            }
 
             // Y lo que le hayan sumado a ESE hechizo por embrujo: el efecto 293, "+#3 de daños
             // básicos". Flecha Helada se lo pone a sí misma, así que la segunda vez que se lanza
@@ -3509,8 +3534,16 @@ namespace Jondo.Unity.Server.Handlers
                 int monsterGrade = monster.SpellGrades.TryGetValue(spell, out int g) ? g : 1;
 
                 var data = DatabaseManager.GetSpellCombatData(spell, monsterGrade);
-                if (data == null) continue;
-                if (data.APCost <= 0) continue;
+                if (data == null)
+                {
+                    Program.LogDebug($"[Combate] IA {monster.Id} omite {spell}: no hay datos de combate.");
+                    continue;
+                }
+                if (data.APCost <= 0)
+                {
+                    Program.LogDebug($"[Combate] IA {monster.Id} omite {spell}: coste de PA {data.APCost}.");
+                    continue;
+                }
 
                 // CUÁNTAS VECES SE PUEDE LANZAR. El cero quiere decir «sin límite», y entonces
                 // manda lo que dé el bolsillo. Lanzando uno solo por hechizo, que es lo que se
@@ -3520,19 +3553,35 @@ namespace Jondo.Unity.Server.Handlers
 
                 for (int vez = 0; vez < tope; vez++)
                 {
-                    if (data.APCost > monster.CurrentAP) break;
+                    if (data.APCost > monster.CurrentAP)
+                    {
+                        Program.LogDebug($"[Combate] IA {monster.Id} no puede lanzar {spell}: " +
+                                         $"cuesta {data.APCost} PA y le quedan {monster.CurrentAP}.");
+                        break;
+                    }
                     if (lanzados >= TopeDeLanzamientosPorTurno) break;
                     if (!prey.IsAlive) break;
 
                     // A QUIÉN APUNTA ESTE HECHIZO. No tiene por qué ser la presa, y apuntarlo todo
                     // a ella es lo que hacía que un jalamutín te lanzara su curación a la cara.
                     var objetivo = ObjetivoDe(fight, monster, spell, monsterGrade, prey, data);
-                    if (objetivo == null || !objetivo.IsAlive) break;
+                    if (objetivo == null || !objetivo.IsAlive)
+                    {
+                        Program.LogDebug($"[Combate] IA {monster.Id} no encuentra objetivo válido " +
+                                         $"para {spell}.");
+                        break;
+                    }
 
                     // Y el alcance se mide contra el objetivo ELEGIDO, no contra la presa. Ésa era
                     // la línea que dejaba muertos los hechizos de alcance cero.
                     int lejos = CellDistance(monster.CellId, objetivo.CellId);
-                    if (lejos < data.MinRange || lejos > data.MaxRange) break;
+                    if (lejos < data.MinRange || lejos > data.MaxRange)
+                    {
+                        Program.LogDebug($"[Combate] IA {monster.Id} no lanza {spell}: objetivo " +
+                                         $"a {lejos}, alcance {data.MinRange}-{data.MaxRange}, " +
+                                         $"PM restantes {monster.CurrentMP}.");
+                        break;
+                    }
 
                     // Y LA LINEA DE VISION, que el turno del monstruo no miraba.
                     //
@@ -3545,6 +3594,8 @@ namespace Jondo.Unity.Server.Handlers
                         !MapGeometry.HasLineOfSight(monster.CellId, objetivo.CellId,
                                                     MapManager.GetLosBlockers(fight.ArenaMapId)))
                     {
+                        Program.LogDebug($"[Combate] IA {monster.Id} no lanza {spell}: ligne de vue " +
+                                         $"bloquée de {monster.CellId} vers {objetivo.CellId}.");
                         break;
                     }
 
@@ -3596,6 +3647,13 @@ namespace Jondo.Unity.Server.Handlers
                         Network.FightProtocol.BuildSequenceEnd(fight.SiguienteAccion(), monster.Id,
                                                                Network.FightProtocol.ActionSequence)));
                 }
+            }
+
+            if (lanzados == 0)
+            {
+                Program.LogDebug($"[Combate] IA {monster.Id} termine sans lancer de sort: " +
+                                 $"PA {monster.CurrentAP}/{monster.MaxAP}, PM " +
+                                 $"{monster.CurrentMP}/{monster.MaxMP}, case {monster.CellId}.");
             }
 
             if (await CheckFightOverAsync(stream, fight)) return;
@@ -3695,7 +3753,8 @@ namespace Jondo.Unity.Server.Handlers
                     else if (t == "a" || t == "g") aLosSuyos = true;
                     else if (t == "C") alLanzador = true;
 
-                    if (efecto.EffectId == EffectSupport.Heal && (t == "a" || t == "g"))
+                    if (Managers.EffectEngine.EsCuraFija(efecto.EffectId) &&
+                        (t == "a" || t == "g"))
                         curaALosSuyos = true;
                 }
             }
@@ -3722,7 +3781,7 @@ namespace Jondo.Unity.Server.Handlers
         {
             foreach (var efecto in Managers.SpellEffects.De(hechizo, grado))
             {
-                if (efecto.EffectId != EffectSupport.Heal) continue;
+                if (!Managers.EffectEngine.EsCuraFija(efecto.EffectId)) continue;
                 foreach (var trozo in (efecto.TargetMask ?? "").Split(','))
                 {
                     string t = trozo.Trim().TrimStart('*');

--- a/Jondo.Unity.Server/Handlers/FightHandler.cs
+++ b/Jondo.Unity.Server/Handlers/FightHandler.cs
@@ -9,6 +9,7 @@ using System.Threading.Tasks;
 using Google.Protobuf;
 using Jondo.Unity.Server.Network;
 using Jondo.Unity.Server.Managers;
+using Jondo.Unity.World.Combat;
 using Jondo.Unity.World.Fights;
 using Jondo.Unity.World.Maps;
 using static Jondo.Unity.Server.Network.NetworkEnvelope;
@@ -1859,11 +1860,12 @@ namespace Jondo.Unity.Server.Handlers
             // Y el reloj, con la MISMA duración que se le acaba de decir al cliente.
             ArrancarElReloj(stream, fight, fighter, duration);
 
-            // El monstruo juega solo: no hay nadie que pulse por él. Un invocado NO pasa por la
-            // inteligencia de los monstruos —no persigue ni ataca— porque lo suyo ya lo ha hecho
-            // su propio hechizo en las actitudes de principio de turno: la baliza se cura o
-            // empuja ahí y no tiene que hacer nada más.
-            if (fighter.IsMonster && !fighter.EsInvocado)
+            // Los invocados ACTIVOS traen la misma lista de hechizos de MonsterTemplates que un
+            // monstruo normal y juegan con la misma inteligencia. Los pasivos —balizas, glifos—
+            // no traen ataques: su startingSpellId ya ha disparado sus actitudes y pasan en el
+            // acto. Separarlos sólo por EsInvocado dejaba a la Dragoune sin hacer absolutamente
+            // nada aunque estuviera viva en el tablero.
+            if (fighter.IsMonster && (!fighter.EsInvocado || fighter.SpellIds.Count > 0))
             {
                 await MonsterTurnAsync(stream, fight, fighter);
             }
@@ -2266,6 +2268,12 @@ namespace Jondo.Unity.Server.Handlers
                 return;
             }
 
+            // El startingSpellId de la receta gobierna invocados PASIVOS. Los que caminan y
+            // lanzan hechizos llevan sus acciones en MonsterTemplates.spells, igual que un
+            // monstruo normal. Esta lectura traduce además el grado propio de cada hechizo.
+            var fichaDelMonstruo = DatabaseManager.GetMonsterGradeStats(
+                plantilla, Math.Max(0, grado - 1));
+
             // Cuántas puede llevar a la vez: la característica 26, que el cliente pinta como
             // "Invocación" en el panel. Sale de la base más el equipo, como todo lo demás.
             int tope = TopeDeInvocaciones(quienInvoca, fight.RoundNumber);
@@ -2304,6 +2312,16 @@ namespace Jondo.Unity.Server.Handlers
                 FireResPct = receta.ResistenciaFuego,
                 WaterResPct = receta.ResistenciaAgua,
                 AirResPct = receta.ResistenciaAire,
+                Strength = receta.Fuerza,
+                Intelligence = receta.Inteligencia,
+                Chance = receta.Suerte,
+                Agility = receta.Agilidad,
+                EarthDamage = receta.DanoTierra,
+                FireDamage = receta.DanoFuego,
+                WaterDamage = receta.DanoAgua,
+                AirDamage = receta.DanoAire,
+                SpellIds = fichaDelMonstruo?.SpellIds ?? new List<int>(),
+                SpellGrades = fichaDelMonstruo?.SpellGrades ?? new Dictionary<int, int>(),
             };
             invocado.MaxHP = Managers.Summons.VidaDelInvocado(receta.Vida, quienInvoca.Level,
                                                               receta.VidaFija);
@@ -2312,11 +2330,11 @@ namespace Jondo.Unity.Server.Handlers
             int vive = Managers.Summons.RondasQueVive(plantilla);
             invocado.MuereEnRonda = vive > 0 ? fight.RoundNumber + vive : -1;
 
-            // ¿Le toca turno? Sólo si su hechizo tiene algo que hacer al empezarlo. La Baliza de
-            // Supervivencia lo tiene —se cura sola— y la Táctica no, que sólo reacciona a lo que
-            // le pase alrededor; por eso en las capturas la primera juega y la segunda no aparece
-            // ni una vez en el carrusel.
-            invocado.JuegaTurno = TieneAlgoQueHacerAlEmpezar(receta.HechizoPropio,
+            // Juega si tiene acciones activas O si su hechizo de comportamiento hace algo al
+            // empezar el turno. Mirar sólo startingSpellId excluía a todos los invocados activos:
+            // la Dragoune tiene ahí cero, pero trae 31166 y 31168 en su lista de ataques.
+            invocado.JuegaTurno = invocado.SpellIds.Count > 0 ||
+                                  TieneAlgoQueHacerAlEmpezar(receta.HechizoPropio,
                                                              receta.GradoDelHechizoPropio);
 
             fight.Invocar(invocado, quienInvoca);
@@ -2332,7 +2350,9 @@ namespace Jondo.Unity.Server.Handlers
 
             Program.LogDebug($"[Combate] {quienInvoca.Id} invoca la plantilla {plantilla} grado " +
                              $"{grado} como {invocado.Id} en la casilla {celda} con " +
-                             $"{invocado.MaxHP} de vida y el hechizo {receta.HechizoPropio}.");
+                             $"{invocado.MaxHP} de vida, actitud {receta.HechizoPropio}, " +
+                             $"hechizos [{string.Join(",", invocado.SpellIds)}] y " +
+                             $"turno activo={invocado.JuegaTurno}.");
 
             // Su hechizo pasa a ser su actitud, y se lanza en el acto para que queden puestos sus
             // enganches y su cuenta atrás.
@@ -3391,17 +3411,60 @@ namespace Jondo.Unity.Server.Handlers
                 if (distance < best) { best = distance; prey = enemy; }
             }
 
+            // Un invocado de apoyo no debe salir corriendo hacia el enemigo antes de usar la
+            // cura que lleva en la propia lista de ataques. La Dragoune tiene un hechizo mixto:
+            // sobre un enemigo roba vida, sobre un aliado devuelve vida. Si hay alguien herido,
+            // primero se queda a distancia de cura —o se acerca a ella— y luego ya ataca con lo
+            // que le sobre.
+            Fighter? aliadoHerido = MasHeridoDeLosSuyos(fight, monster);
+            SpellCombatData? curaDisponible = null;
+            if (aliadoHerido != null)
+            {
+                foreach (int spell in monster.SpellIds)
+                {
+                    int spellGrade = monster.SpellGrades.TryGetValue(spell, out int g) ? g : 1;
+                    if (!CuraAliados(spell, spellGrade)) continue;
+                    var data = DatabaseManager.GetSpellCombatData(spell, spellGrade);
+                    if (data == null || data.APCost <= 0 || data.APCost > monster.CurrentAP) continue;
+                    curaDisponible = data;
+                    break;
+                }
+            }
+
             // A QUÉ DISTANCIA LE CONVIENE PONERSE, que no es «al lado» siempre.
             //
             // Antes se pegaba: allowed = Min(CurrentMP, best - 1). Y pegado no se pueden lanzar los
             // 857 hechizos de monstruo (11,3 % del arsenal) que tienen alcance mínimo mayor que
             // uno. El bicho gastaba los puntos de movimiento en meterse justo donde no podía hacer
             // nada, y encima ya no le quedaban para volver a separarse.
+            Fighter? objetivoDeMovimiento = prey;
+            int distanciaAlObjetivo = best;
             int deseada = prey != null ? DistanciaQueLeConviene(monster, best) : 1;
 
-            if (prey != null && deseada != best && monster.CurrentMP > 0)
+            if (aliadoHerido != null && curaDisponible != null)
             {
-                var walked = PathToward(fight, monster.CellId, prey.CellId, monster.CurrentMP, deseada);
+                objetivoDeMovimiento = aliadoHerido;
+                distanciaAlObjetivo = CellDistance(monster.CellId, aliadoHerido.CellId);
+
+                // Si ya puede curarlo, no se mueve: acercarse primero al enemigo podía sacar al
+                // dueño del alcance 1-2 y desperdiciar justo el hechizo que se quería lanzar.
+                if (distanciaAlObjetivo >= curaDisponible.MinRange &&
+                    distanciaAlObjetivo <= curaDisponible.MaxRange)
+                {
+                    deseada = distanciaAlObjetivo;
+                }
+                else
+                {
+                    deseada = Math.Clamp(distanciaAlObjetivo,
+                                         curaDisponible.MinRange, curaDisponible.MaxRange);
+                }
+            }
+
+            if (objetivoDeMovimiento != null && deseada != distanciaAlObjetivo &&
+                monster.CurrentMP > 0)
+            {
+                var walked = PathToward(fight, monster.CellId, objetivoDeMovimiento.CellId,
+                                        monster.CurrentMP, deseada);
                 if (walked.Count > 1)
                 {
                     var path = walked.ConvertAll(c => (long)c);
@@ -3422,13 +3485,23 @@ namespace Jondo.Unity.Server.Handlers
                     await WriteFrameAsync(stream, ConnectionProtocol.Push(Op.Jwi,
                         Network.FightProtocol.BuildSequenceEnd(fight.SiguienteAccion(), monster.Id,
                                                                Network.FightProtocol.WalkSequence)));
-                    best = CellDistance(monster.CellId, prey.CellId);
+                    distanciaAlObjetivo = CellDistance(monster.CellId, objetivoDeMovimiento.CellId);
                 }
             }
 
-            // Y a pegar con lo que tenga, mientras le lleguen los puntos de acción.
+            // Primero las curas si hacen falta, luego los ataques. Conservar sin más el orden de
+            // MonsterTemplates hacía que un invocado gastara todos sus PA en el primer ataque y
+            // nunca alcanzara el hechizo de apoyo que venía detrás.
+            var hechizosDelTurno = monster.SpellIds
+                .OrderByDescending(spell => aliadoHerido != null &&
+                                             CuraAliados(spell,
+                                                 monster.SpellGrades.TryGetValue(spell, out int g)
+                                                     ? g : 1))
+                .ToList();
+
+            // Y a lanzar con lo que tenga, mientras le lleguen los puntos de acción.
             int lanzados = 0;
-            foreach (int spell in monster.SpellIds)
+            foreach (int spell in hechizosDelTurno)
             {
                 if (prey == null || !prey.IsAlive) break;
 
@@ -3475,8 +3548,21 @@ namespace Jondo.Unity.Server.Handlers
                         break;
                     }
 
+                    monster.LanzadosEsteTurno.TryGetValue(spell, out int delHechizo);
+                    if (data.MaxCastPerTurn > 0 && delHechizo >= data.MaxCastPerTurn) break;
+
+                    monster.LanzadosPorObjetivo.TryGetValue((spell, objetivo.Id),
+                                                            out int sobreObjetivo);
+                    if (data.MaxCastPerTarget > 0 && sobreObjetivo >= data.MaxCastPerTarget) break;
+
                     monster.CurrentAP -= data.APCost;
+                    monster.LanzadosEsteTurno[spell] = delHechizo + 1;
+                    monster.LanzadosPorObjetivo[(spell, objetivo.Id)] = sobreObjetivo + 1;
                     lanzados++;
+
+                    Program.LogDebug($"[Combate] IA {monster.Id} lanza {spell} grado " +
+                                     $"{monsterGrade} sobre {objetivo.Id} desde {monster.CellId} " +
+                                     $"a {objetivo.CellId}; PA {monster.CurrentAP}/{monster.MaxAP}.");
 
                     // Y su identificador, para que su lanzamiento también diga QUÉ se lanza.
                     int spellLevel = data.SpellLevelId;
@@ -3599,6 +3685,7 @@ namespace Jondo.Unity.Server.Handlers
             if (data.MaxRange <= 0) return monster;
 
             bool aEnemigos = false, aLosSuyos = false, alLanzador = false;
+            bool curaALosSuyos = false;
             foreach (var efecto in Managers.SpellEffects.De(hechizo, grado))
             {
                 foreach (var trozo in (efecto.TargetMask ?? "").Split(','))
@@ -3607,15 +3694,42 @@ namespace Jondo.Unity.Server.Handlers
                     if (t == "A") aEnemigos = true;
                     else if (t == "a" || t == "g") aLosSuyos = true;
                     else if (t == "C") alLanzador = true;
+
+                    if (efecto.EffectId == EffectSupport.Heal && (t == "a" || t == "g"))
+                        curaALosSuyos = true;
                 }
             }
 
-            // Si toca a los de enfrente va a la presa, aunque además toque a los suyos: el Ojo de
-            // Topo se lleva por delante a los aliados que pille dentro y aun así se lanza al enemigo.
+            // Un hechizo mixto de ataque/cura cambia de rama según la casilla apuntada. Antes la
+            // presencia de cualquier efecto «A» ganaba siempre, de modo que la Dragoune usaba su
+            // 31168 exclusivamente contra el enemigo y jamás alcanzaba el efecto 108 «a».
+            if (curaALosSuyos)
+            {
+                var herido = MasHeridoDeLosSuyos(fight, monster);
+                if (herido != null) return herido;
+            }
+
+            // Si toca a los de enfrente va a la presa, aunque además toque a los suyos: un ataque
+            // de zona puede llevarse por delante a los aliados y aun así se lanza al enemigo.
             if (aEnemigos) return presa;
             if (aLosSuyos) return MasHeridoDeLosSuyos(fight, monster) ?? monster;
             if (alLanzador) return monster;
             return presa;
+        }
+
+        /// <summary>¿Tiene al menos una cura inmediata dirigida a un aliado que no sea el lanzador?</summary>
+        private static bool CuraAliados(int hechizo, int grado)
+        {
+            foreach (var efecto in Managers.SpellEffects.De(hechizo, grado))
+            {
+                if (efecto.EffectId != EffectSupport.Heal) continue;
+                foreach (var trozo in (efecto.TargetMask ?? "").Split(','))
+                {
+                    string t = trozo.Trim().TrimStart('*');
+                    if (t == "a" || t == "g") return true;
+                }
+            }
+            return false;
         }
 
         /// <summary>El de su bando al que más vida le falta, que es a quien se cura.</summary>
@@ -3626,7 +3740,9 @@ namespace Jondo.Unity.Server.Handlers
             int falta = 0;
             foreach (var f in suyos)
             {
-                if (f == null || !f.IsAlive) continue;
+                // Las máscaras «a» y «g» excluyen al lanzador; devolvérselo a sí mismo hacía que
+                // apuntara la animación a una casilla sobre la que el motor no podía curar a nadie.
+                if (f == null || f == monster || !f.IsAlive) continue;
                 int suya = f.MaxHP - f.CurrentHP;
                 if (suya > falta) { falta = suya; peor = f; }
             }

--- a/Jondo.Unity.Server/Handlers/FightHandler.cs
+++ b/Jondo.Unity.Server/Handlers/FightHandler.cs
@@ -776,6 +776,7 @@ namespace Jondo.Unity.Server.Handlers
             Poner(27, sabiduria / PorCadaDiez);   // esquiva de puntos de acción
             Poner(28, sabiduria / PorCadaDiez);   // esquiva de puntos de movimiento
             Poner(12, GameState.StatWisdom);      // sabiduría
+            Poner(49, 0);                         // curas fijas
             Poner(26, 0);                         // invocaciones
             Poner(50, 0);                         // reenvío
             Poner(75, 0);                         // erosión

--- a/Jondo.Unity.Server/Managers/EffectEngine.cs
+++ b/Jondo.Unity.Server/Managers/EffectEngine.cs
@@ -248,8 +248,42 @@ namespace Jondo.Unity.Server.Managers
 
         public static bool VaAlSuelo(int efecto) => AlSuelo.Contains(efecto);
 
+        /// <summary>"Cura: #1 a #2". La inteligencia multiplica la base y la 49 se suma al final.</summary>
+        private const int CuraFija = EffectSupport.Heal;
+
+        /// <summary>La característica de Inteligencia, que multiplica las curas fijas.</summary>
+        private const int Inteligencia = 15;
+
+        /// <summary>La característica 49, «Curas»: puntos planos añadidos después de la Inteligencia.</summary>
+        private const int Curas = 49;
+
+        /// <summary>El efecto 1159, «Curas recibidas x#1%».</summary>
+        private const int CurasRecibidasPorCiento = 1159;
+
         /// <summary>"Cura: #1% de los PdV máximos". El dado es el porcentaje.</summary>
         private const int CuraPorcentual = EffectSupport.HealPercent;
+
+        /// <summary>
+        /// Convierte la tirada de un efecto 108 en puntos de vida.
+        ///
+        ///   cura = base × (100 + inteligencia) / 100 + curas fijas
+        ///
+        /// La potencia y los daños no intervienen. El multiplicador de curas recibidas va al final,
+        /// igual que el multiplicador de daños sufridos en la fórmula de daño.
+        /// </summary>
+        public static int CalcularCuraFija(int curaBase, int inteligencia, int curasFijas,
+                                          int multiplicadorRecibido = 100)
+        {
+            if (curaBase <= 0 || multiplicadorRecibido <= 0) return 0;
+
+            long porcentaje = Math.Max(0L, 100L + inteligencia);
+            long calculada = (long)curaBase * porcentaje / 100L + curasFijas;
+            if (calculada <= 0) return 0;
+
+            double multiplicada = calculada * (multiplicadorRecibido / 100.0);
+            if (multiplicada >= int.MaxValue) return int.MaxValue;
+            return Math.Max(0, (int)Math.Round(multiplicada));
+        }
 
         /// <summary>Los dos números de característica de los puntos.</summary>
         /// <summary>
@@ -334,6 +368,13 @@ namespace Jondo.Unity.Server.Managers
                 }
                 if (!leToca) continue;
 
+                // Igual que el daño, una cura con zona tira el dado una sola vez por lanzamiento.
+                // Todos los destinatarios parten del mismo número y sólo cambia la caída por su
+                // distancia al centro.
+                int tiradaCompartida = efecto.EffectId == CuraFija || efecto.EffectId == CuraPorcentual
+                    ? DelDado(efecto.DiceNum, efecto.DiceSide, efecto.Value)
+                    : int.MinValue;
+
                 // Lo que se pone EN EL SUELO no busca a nadie: va a la casilla, esté quien esté.
                 //
                 // Aquí se caían las balizas. El efecto 181 lleva máscara "a,A" y zona de punto, y
@@ -344,7 +385,7 @@ namespace Jondo.Unity.Server.Managers
                 if (VaAlSuelo(efecto.EffectId))
                 {
                     var puesta = Aplicar(combate, quienLanza, quienLanza, hechizo, grado, efecto,
-                                         ronda, celdaApuntada);
+                                         ronda, celdaApuntada, tiradaCompartida);
                     if (puesta != null) fuera.Add(puesta);
                     continue;
                 }
@@ -358,7 +399,7 @@ namespace Jondo.Unity.Server.Managers
                 foreach (var sobre in AQuien(combate, quienLanza, objetivo, efecto, celdaApuntada))
                 {
                     var hecho = Aplicar(combate, quienLanza, sobre, hechizo, grado, efecto, ronda,
-                                        celdaApuntada);
+                                        celdaApuntada, tiradaCompartida);
                     if (unaSolaVez)
                     {
                         if (hecho != null) fuera.Add(hecho);
@@ -529,7 +570,7 @@ namespace Jondo.Unity.Server.Managers
 
         private static Outcome Aplicar(FightInstance combate, Fighter quienLanza, Fighter sobre,
                                             int hechizo, int grado, SpellEffect efecto, int ronda,
-                                            int celdaApuntada = -1)
+                                            int celdaApuntada = -1, int tiradaCompartida = int.MinValue)
         {
             // El daño lo lleva quien ya lo llevaba; aquí no se toca.
             if (efecto.EffectId >= DanoPrimero && efecto.EffectId <= DanoUltimo) return null;
@@ -783,15 +824,60 @@ namespace Jondo.Unity.Server.Managers
                 };
             }
 
+            // Las curaciones fijas. La tirada es una sola para toda la zona; después se aplica la
+            // caída de la casilla, la Inteligencia, las curas planas y lo que multiplique las curas
+            // recibidas por el objetivo. No intervienen ni la potencia ni los daños.
+            if (efecto.EffectId == CuraFija)
+            {
+                int curaBase = tiradaCompartida != int.MinValue
+                    ? tiradaCompartida
+                    : DelDado(efecto.DiceNum, efecto.DiceSide, efecto.Value);
+                if (curaBase <= 0) return null;
+
+                int lejos = celdaApuntada >= 0
+                    ? Jondo.Unity.World.Maps.MapGeometry.Distance(celdaApuntada, sobre.CellId)
+                    : 0;
+                curaBase = ConLaCaidaDeLaZona(curaBase, efecto, lejos);
+
+                int inteligencia = quienLanza.Intelligence + quienLanza.Buffs.De(Inteligencia, ronda);
+                int curasFijas = quienLanza.Otra(Curas) + quienLanza.Buffs.De(Curas, ronda);
+                int multiplicador = sobre.Buffs.Multiplicador(CurasRecibidasPorCiento, ronda);
+                int puntos = CalcularCuraFija(curaBase, inteligencia, curasFijas, multiplicador);
+                puntos = Math.Min(puntos, Math.Max(0, sobre.MaxHP - sobre.CurrentHP));
+                if (puntos <= 0) return null;
+
+                sobre.CurrentHP += puntos;
+                return new Outcome
+                {
+                    Sobre = sobre, Efecto = efecto,
+                    HechizoOrigen = hechizo, NivelOrigen = grado,
+                    Cura = puntos,
+                };
+            }
+
             // Las curaciones por tanto por ciento de la vida máxima. El dado es el PORCENTAJE, no
             // los puntos: la Baliza de Supervivencia cura un siete por ciento del tope de quien
-            // recibe, y en el cable eso viaja ya resuelto en puntos.
+            // recibe, y en el cable eso viaja ya resuelto en puntos. No reciben Inteligencia ni
+            // curas fijas, pero sí la caída de zona y los multiplicadores de curas recibidas.
             if (efecto.EffectId == CuraPorcentual)
             {
-                int cuanto = efecto.DiceNum != 0 ? efecto.DiceNum : efecto.Value;
+                int cuanto = tiradaCompartida != int.MinValue
+                    ? tiradaCompartida
+                    : DelDado(efecto.DiceNum, efecto.DiceSide, efecto.Value);
                 if (cuanto <= 0) return null;
 
-                int puntos = Math.Max(1, sobre.MaxHP * cuanto / 100);
+                int lejos = celdaApuntada >= 0
+                    ? Jondo.Unity.World.Maps.MapGeometry.Distance(celdaApuntada, sobre.CellId)
+                    : 0;
+                cuanto = ConLaCaidaDeLaZona(cuanto, efecto, lejos);
+                if (cuanto <= 0) return null;
+
+                long porVida = Math.Max(1L, (long)sobre.MaxHP * cuanto / 100L);
+                int multiplicador = sobre.Buffs.Multiplicador(CurasRecibidasPorCiento, ronda);
+                double multiplicada = porVida * (Math.Max(0, multiplicador) / 100.0);
+                int puntos = multiplicada >= int.MaxValue
+                    ? int.MaxValue
+                    : Math.Max(0, (int)Math.Round(multiplicada));
                 puntos = Math.Min(puntos, Math.Max(0, sobre.MaxHP - sobre.CurrentHP));
                 if (puntos <= 0) return null;
 

--- a/Jondo.Unity.Server/Managers/EffectEngine.cs
+++ b/Jondo.Unity.Server/Managers/EffectEngine.cs
@@ -51,6 +51,10 @@ namespace Jondo.Unity.Server.Managers
         /// <summary>Los puntos de vida que se han devuelto, si el efecto cura.</summary>
         public int Cura { get; init; }
 
+        /// <summary>When non-zero, set this spell's cooldown to <see cref="TurnosDeRecarga"/>.</summary>
+        public int HechizoConRecarga { get; init; }
+        public int TurnosDeRecarga { get; init; }
+
         /// <summary>
         /// El daño de haberse chocado al empujar, YA CALCULADO PERO SIN APLICAR.
         ///
@@ -117,11 +121,19 @@ namespace Jondo.Unity.Server.Managers
         private static readonly HashSet<int> PorLoErosionado
             = new HashSet<int> { 1092, 1093, 1094, 1095, 1096, 1118, 1119, 1120, 1121, 1122 };
 
+        private static readonly HashSet<int> DanosEspeciales = new HashSet<int>
+        {
+            EffectSupport.CasterCurrentHealthDamage,
+            EffectSupport.CasterMissingHealthDamage,
+            EffectSupport.BestElementDamage,
+        };
+
         public static bool PegaSegunLoErosionado(int efecto) => PorLoErosionado.Contains(efecto);
 
         /// <summary>¿Este efecto pega?</summary>
         public static bool EsDeDano(int efecto)
-            => (efecto >= DanoPrimero && efecto <= DanoUltimo) || PegaSegunLoErosionado(efecto);
+            => (efecto >= DanoPrimero && efecto <= DanoUltimo) ||
+               PegaSegunLoErosionado(efecto) || DanosEspeciales.Contains(efecto);
 
         /// <summary>
         /// Los golpes que da un hechizo: uno por cada efecto de daño que le toque al objetivo.
@@ -142,8 +154,7 @@ namespace Jondo.Unity.Server.Managers
 
                 // El elemento lo dice el propio hechizo en su effectElement; si no lo trae, el
                 // catálogo por el número de efecto.
-                int elemento = efecto.Element >= 0 ? efecto.Element
-                                                   : DatabaseManager.EffectElement(efecto.EffectId);
+                int elemento = ElementoDelGolpe(quienLanza, efecto, combate.RoundNumber);
                 foreach (var sobre in AQuien(combate, quienLanza, objetivo, efecto, celdaApuntada))
                 {
                     if (sobre == null || !sobre.IsAlive) continue;
@@ -157,6 +168,31 @@ namespace Jondo.Unity.Server.Managers
                 }
             }
             return fuera;
+        }
+
+        private static int ElementoDelGolpe(Fighter quienLanza, SpellEffect efecto, int ronda)
+        {
+            if (efecto.EffectId != EffectSupport.BestElementDamage)
+                return efecto.Element >= 0 ? efecto.Element
+                                           : DatabaseManager.EffectElement(efecto.EffectId);
+
+            var elementos = new[]
+            {
+                (Elemento: 1, Valor: quienLanza.Strength + quienLanza.Buffs.De(10, ronda)),
+                (Elemento: 2, Valor: quienLanza.Intelligence + quienLanza.Buffs.De(15, ronda)),
+                (Elemento: 3, Valor: quienLanza.Chance + quienLanza.Buffs.De(13, ronda)),
+                (Elemento: 4, Valor: quienLanza.Agility + quienLanza.Buffs.De(14, ronda)),
+            };
+
+            int mejorElemento = 1;
+            int mejorValor = int.MinValue;
+            foreach (var candidato in elementos)
+            {
+                if (candidato.Valor <= mejorValor) continue;
+                mejorElemento = candidato.Elemento;
+                mejorValor = candidato.Valor;
+            }
+            return mejorElemento;
         }
 
         /// <summary>
@@ -235,6 +271,8 @@ namespace Jondo.Unity.Server.Managers
 
         /// <summary>"Invoca: #1". La plantilla del bicho viaja en el dado.</summary>
         public const int Invocar = EffectSupport.Summon;
+        public const int InvocarControlable = EffectSupport.ControllableSummon;
+        private const int FijarRecarga = EffectSupport.SetCooldown;
 
         /// <summary>
         /// Los efectos que colocan algo EN UNA CASILLA en vez de sobre alguien: una invocación,
@@ -244,12 +282,22 @@ namespace Jondo.Unity.Server.Managers
         ///   401  "Coloca un glifo de inicio de turno"
         ///   1091 "Coloca un glifo aura"
         /// </summary>
-        private static readonly HashSet<int> AlSuelo = new HashSet<int> { 181, 400, 401, 1091 };
+        private static readonly HashSet<int> AlSuelo = new HashSet<int>
+        {
+            EffectSupport.Summon, EffectSupport.ControllableSummon, 400, 401, 1091
+        };
 
         public static bool VaAlSuelo(int efecto) => AlSuelo.Contains(efecto);
 
         /// <summary>"Cura: #1 a #2". La inteligencia multiplica la base y la 49 se suma al final.</summary>
         private const int CuraFija = EffectSupport.Heal;
+        private static readonly HashSet<int> CurasFijas = new HashSet<int>
+        {
+            EffectSupport.Heal, EffectSupport.WaterHeal, EffectSupport.AirHeal,
+            EffectSupport.EarthHeal,
+        };
+
+        public static bool EsCuraFija(int efecto) => CurasFijas.Contains(efecto);
 
         /// <summary>La característica de Inteligencia, que multiplica las curas fijas.</summary>
         private const int Inteligencia = 15;
@@ -371,7 +419,7 @@ namespace Jondo.Unity.Server.Managers
                 // Igual que el daño, una cura con zona tira el dado una sola vez por lanzamiento.
                 // Todos los destinatarios parten del mismo número y sólo cambia la caída por su
                 // distancia al centro.
-                int tiradaCompartida = efecto.EffectId == CuraFija || efecto.EffectId == CuraPorcentual
+                int tiradaCompartida = EsCuraFija(efecto.EffectId) || efecto.EffectId == CuraPorcentual
                     ? DelDado(efecto.DiceNum, efecto.DiceSide, efecto.Value)
                     : int.MinValue;
 
@@ -439,6 +487,7 @@ namespace Jondo.Unity.Server.Managers
             bool alLanzador = false, aLosMios = false, aLosDeEnfrente = false, aLasInvocaciones = false;
             var pideEstado = new List<int>();
             var pideNoEstado = new List<int>();
+            int vidaMinima = -1, vidaMaxima = -1;
 
             foreach (var trozo in mascara.Split(','))
             {
@@ -465,6 +514,16 @@ namespace Jondo.Unity.Server.Managers
                 if (t.Length > 1 && (t[0] == 'e' || t[0] == 'E') && int.TryParse(t.Substring(1), out int estado))
                 {
                     if (t[0] == 'E') pideEstado.Add(estado); else pideNoEstado.Add(estado);
+                    continue;
+                }
+
+                // V50 / v50 are upper/lower target vitality bands. The Gobgob Glouton carries
+                // one health-based neutral damage formula for each side of that threshold.
+                if (t.Length > 1 && (t[0] == 'V' || t[0] == 'v') &&
+                    int.TryParse(t.Substring(1), out int porcentaje))
+                {
+                    if (t[0] == 'V') vidaMinima = porcentaje;
+                    else vidaMaxima = porcentaje;
                 }
             }
 
@@ -515,6 +574,9 @@ namespace Jondo.Unity.Server.Managers
                 bool vale = true;
                 foreach (int estado in pideEstado) if (!quien.Buffs.TieneEstado(estado)) vale = false;
                 foreach (int estado in pideNoEstado) if (quien.Buffs.TieneEstado(estado)) vale = false;
+                int vida = quien.MaxHP > 0 ? (int)((long)quien.CurrentHP * 100L / quien.MaxHP) : 0;
+                if (vidaMinima >= 0 && vida < vidaMinima) vale = false;
+                if (vidaMaxima >= 0 && vida >= vidaMaxima) vale = false;
                 if (vale) yield return quien;
             }
         }
@@ -573,7 +635,7 @@ namespace Jondo.Unity.Server.Managers
                                             int celdaApuntada = -1, int tiradaCompartida = int.MinValue)
         {
             // El daño lo lleva quien ya lo llevaba; aquí no se toca.
-            if (efecto.EffectId >= DanoPrimero && efecto.EffectId <= DanoUltimo) return null;
+            if (EsDeDano(efecto.EffectId)) return null;
 
             if (efecto.EffectId == Empujar || efecto.EffectId == Tirar ||
                 efecto.EffectId == Retroceder || efecto.EffectId == Avanzar)
@@ -690,7 +752,7 @@ namespace Jondo.Unity.Server.Managers
                 };
             }
 
-            if (efecto.EffectId == Invocar)
+            if (efecto.EffectId == Invocar || efecto.EffectId == InvocarControlable)
             {
                 // "Invoca: #1", con la plantilla del bicho en el dado. No lo saca al tablero el
                 // motor: hace falta repartir identificador, rehacer el orden de turnos y avisar
@@ -701,6 +763,19 @@ namespace Jondo.Unity.Server.Managers
                     Sobre = sobre, Efecto = efecto,
                     HechizoOrigen = hechizo, NivelOrigen = grado,
                     Invoca = efecto.DiceNum,
+                };
+            }
+
+            if (efecto.EffectId == FijarRecarga)
+            {
+                int turnos = efecto.Value != 0 ? efecto.Value : efecto.DiceSide;
+                if (efecto.DiceNum <= 0 || turnos <= 0) return null;
+                return new Outcome
+                {
+                    Sobre = sobre, Efecto = efecto,
+                    HechizoOrigen = hechizo, NivelOrigen = grado,
+                    HechizoConRecarga = efecto.DiceNum,
+                    TurnosDeRecarga = turnos,
                 };
             }
 
@@ -827,7 +902,7 @@ namespace Jondo.Unity.Server.Managers
             // Las curaciones fijas. La tirada es una sola para toda la zona; después se aplica la
             // caída de la casilla, la Inteligencia, las curas planas y lo que multiplique las curas
             // recibidas por el objetivo. No intervienen ni la potencia ni los daños.
-            if (efecto.EffectId == CuraFija)
+            if (EsCuraFija(efecto.EffectId))
             {
                 int curaBase = tiradaCompartida != int.MinValue
                     ? tiradaCompartida
@@ -839,10 +914,16 @@ namespace Jondo.Unity.Server.Managers
                     : 0;
                 curaBase = ConLaCaidaDeLaZona(curaBase, efecto, lejos);
 
-                int inteligencia = quienLanza.Intelligence + quienLanza.Buffs.De(Inteligencia, ronda);
+                int caracteristicaDeCura = efecto.EffectId switch
+                {
+                    EffectSupport.WaterHeal => quienLanza.Chance + quienLanza.Buffs.De(13, ronda),
+                    EffectSupport.AirHeal => quienLanza.Agility + quienLanza.Buffs.De(14, ronda),
+                    EffectSupport.EarthHeal => quienLanza.Strength + quienLanza.Buffs.De(10, ronda),
+                    _ => quienLanza.Intelligence + quienLanza.Buffs.De(Inteligencia, ronda),
+                };
                 int curasFijas = quienLanza.Otra(Curas) + quienLanza.Buffs.De(Curas, ronda);
                 int multiplicador = sobre.Buffs.Multiplicador(CurasRecibidasPorCiento, ronda);
-                int puntos = CalcularCuraFija(curaBase, inteligencia, curasFijas, multiplicador);
+                int puntos = CalcularCuraFija(curaBase, caracteristicaDeCura, curasFijas, multiplicador);
                 puntos = Math.Min(puntos, Math.Max(0, sobre.MaxHP - sobre.CurrentHP));
                 if (puntos <= 0) return null;
 

--- a/Jondo.Unity.Server/Managers/Summons.cs
+++ b/Jondo.Unity.Server/Managers/Summons.cs
@@ -49,6 +49,20 @@ namespace Jondo.Unity.Server.Managers
         public int ResistenciaAgua { get; init; }
         public int ResistenciaAire { get; init; }
 
+        /// <summary>
+        /// Caracteristicas de combate del grado, incluido su bonusCharacteristics. Estas ultimas
+        /// no son decorativas: por ejemplo la Dragoune lleva aqui 50 de inteligencia, que aumenta
+        /// tanto su golpe de fuego como la cura de su hechizo mixto.
+        /// </summary>
+        public int Fuerza { get; init; }
+        public int Inteligencia { get; init; }
+        public int Suerte { get; init; }
+        public int Agilidad { get; init; }
+        public int DanoTierra { get; init; }
+        public int DanoFuego { get; init; }
+        public int DanoAgua { get; init; }
+        public int DanoAire { get; init; }
+
         /// <summary>El hechizo que gobierna al bicho, y en qué grado.</summary>
         public int HechizoPropio { get; init; }
         public int GradoDelHechizoPropio { get; init; }
@@ -172,8 +186,20 @@ namespace Jondo.Unity.Server.Managers
                 // ocupaba casilla —se podía andar a través de él— y no hacía nada.
                 int vidaFija = Math.Max(0, Entero(gr, "lifePoints"));
                 int bonusVida = 0;
+                int bonusFuerza = 0, bonusInteligencia = 0, bonusSuerte = 0, bonusAgilidad = 0;
+                int danoTierra = 0, danoFuego = 0, danoAgua = 0, danoAire = 0;
                 if (gr.TryGetProperty("bonusCharacteristics", out var bonus))
+                {
                     bonusVida = Entero(bonus, "lifePoints");
+                    bonusFuerza = Entero(bonus, "strength");
+                    bonusInteligencia = Entero(bonus, "intelligence");
+                    bonusSuerte = Entero(bonus, "chance");
+                    bonusAgilidad = Entero(bonus, "agility");
+                    danoTierra = Entero(bonus, "bonusEarthDamage");
+                    danoFuego = Entero(bonus, "bonusFireDamage");
+                    danoAgua = Entero(bonus, "bonusWaterDamage");
+                    danoAire = Entero(bonus, "bonusAirDamage");
+                }
 
                 // El hechizo con el que se porta: el startingSpellId es un SpellLevels.Id.
                 int nivelDelHechizo = Entero(gr, "startingSpellId");
@@ -197,6 +223,14 @@ namespace Jondo.Unity.Server.Managers
                     ResistenciaFuego = Entero(gr, "fireResistance"),
                     ResistenciaAgua = Entero(gr, "waterResistance"),
                     ResistenciaAire = Entero(gr, "airResistance"),
+                    Fuerza = Entero(gr, "strength") + bonusFuerza,
+                    Inteligencia = Entero(gr, "intelligence") + bonusInteligencia,
+                    Suerte = Entero(gr, "chance") + bonusSuerte,
+                    Agilidad = Entero(gr, "agility") + bonusAgilidad,
+                    DanoTierra = danoTierra,
+                    DanoFuego = danoFuego,
+                    DanoAgua = danoAgua,
+                    DanoAire = danoAire,
                     HechizoPropio = hechizo,
                     GradoDelHechizoPropio = gradoDelHechizo,
                 };

--- a/Jondo.Unity.Tests/Combat/EffectSupportTests.cs
+++ b/Jondo.Unity.Tests/Combat/EffectSupportTests.cs
@@ -12,22 +12,21 @@ namespace Jondo.Unity.Tests.Combat
     /// <see cref="EffectSupport"/>, so an effect gaining an implementation without being added here
     /// would not compile.
     ///
-    /// Measured over the 872 effects in <c>world.db</c>: 20 have code, 205 are applied as a
-    /// characteristic, and <b>647 do nothing at all</b> — and 15,841 of the 34,823 spell levels
-    /// carry at least one of those 647.
+    /// Effect 108 is also kept here explicitly because its catalogue row alone cannot reveal that
+    /// the engine now knows how to heal.
     /// </remarks>
     public class EffectSupportTests
     {
         /// <summary>
-        /// Effect 108 is healing, and it does nothing. The card says it heals, the animation plays,
-        /// and nobody's life goes up. It is on 751 spell levels.
+        /// Effect 108 has no characteristic and belongs to category 2, but direct support wins over
+        /// both catalogue fields. It occurs on 751 spell levels.
         /// </summary>
         [Fact]
-        public void Healing_is_still_not_implemented_and_says_so()
+        public void Fixed_healing_is_implemented_despite_its_catalogue_row()
         {
-            // Its catalogue row carries no characteristic, which is exactly why it falls through.
-            Assert.Equal(EffectSupportKind.PanelOnly, EffectSupport.Classify(108, 0, 2));
-            Assert.DoesNotContain(108, EffectSupport.HandledDirectly);
+            Assert.Equal(EffectSupportKind.Direct,
+                         EffectSupport.Classify(EffectSupport.Heal, 0, 2));
+            Assert.Contains(EffectSupport.Heal, EffectSupport.HandledDirectly);
         }
 
         [Theory]
@@ -39,6 +38,7 @@ namespace Jondo.Unity.Tests.Combat
         [InlineData(EffectSupport.RemoveState)]
         [InlineData(EffectSupport.CastSpell)]
         [InlineData(EffectSupport.Summon)]
+        [InlineData(EffectSupport.Heal)]
         [InlineData(EffectSupport.HealPercent)]
         [InlineData(EffectSupport.Kill)]
         public void The_effects_with_code_are_reported_as_such(int effectId)

--- a/Jondo.Unity.Tests/Combat/EffectSupportTests.cs
+++ b/Jondo.Unity.Tests/Combat/EffectSupportTests.cs
@@ -38,9 +38,17 @@ namespace Jondo.Unity.Tests.Combat
         [InlineData(EffectSupport.RemoveState)]
         [InlineData(EffectSupport.CastSpell)]
         [InlineData(EffectSupport.Summon)]
+        [InlineData(EffectSupport.ControllableSummon)]
+        [InlineData(EffectSupport.SetCooldown)]
         [InlineData(EffectSupport.Heal)]
+        [InlineData(EffectSupport.WaterHeal)]
+        [InlineData(EffectSupport.AirHeal)]
+        [InlineData(EffectSupport.EarthHeal)]
         [InlineData(EffectSupport.HealPercent)]
         [InlineData(EffectSupport.Kill)]
+        [InlineData(EffectSupport.CasterCurrentHealthDamage)]
+        [InlineData(EffectSupport.CasterMissingHealthDamage)]
+        [InlineData(EffectSupport.BestElementDamage)]
         public void The_effects_with_code_are_reported_as_such(int effectId)
         {
             Assert.Contains(effectId, EffectSupport.HandledDirectly);

--- a/Jondo.Unity.Tests/Combat/HealingTests.cs
+++ b/Jondo.Unity.Tests/Combat/HealingTests.cs
@@ -1,0 +1,44 @@
+using Jondo.Unity.Server.Managers;
+using Xunit;
+
+namespace Jondo.Unity.Tests.Combat
+{
+    public class HealingTests
+    {
+        [Theory]
+        [InlineData(20, 0, 0, 20)]
+        [InlineData(20, 200, 0, 60)]
+        [InlineData(20, 200, 7, 67)]
+        [InlineData(21, 50, 0, 31)]
+        public void Fixed_healing_uses_intelligence_then_flat_heals(
+            int baseHeal, int intelligence, int flatHeals, int expected)
+            => Assert.Equal(expected,
+                            EffectEngine.CalcularCuraFija(baseHeal, intelligence, flatHeals));
+
+        [Theory]
+        [InlineData(40, 0, 0, 50, 20)]
+        [InlineData(40, 0, 0, 110, 44)]
+        [InlineData(40, 0, 0, 0, 0)]
+        public void Received_healing_multiplier_is_applied_last(
+            int baseHeal, int intelligence, int flatHeals, int multiplier, int expected)
+            => Assert.Equal(expected,
+                            EffectEngine.CalcularCuraFija(
+                                baseHeal, intelligence, flatHeals, multiplier));
+
+        [Theory]
+        [InlineData(20, -100, 5, 5)]
+        [InlineData(20, -200, 0, 0)]
+        [InlineData(20, 0, -25, 0)]
+        [InlineData(0, 500, 500, 0)]
+        public void Fixed_healing_never_becomes_negative(
+            int baseHeal, int intelligence, int flatHeals, int expected)
+            => Assert.Equal(expected,
+                            EffectEngine.CalcularCuraFija(baseHeal, intelligence, flatHeals));
+
+        [Fact]
+        public void Fixed_healing_saturates_instead_of_overflowing()
+            => Assert.Equal(int.MaxValue,
+                            EffectEngine.CalcularCuraFija(
+                                int.MaxValue, int.MaxValue, int.MaxValue, int.MaxValue));
+    }
+}

--- a/Jondo.Unity.Tests/Combat/OsamodasEffectTests.cs
+++ b/Jondo.Unity.Tests/Combat/OsamodasEffectTests.cs
@@ -1,0 +1,31 @@
+using Jondo.Unity.Server.Managers;
+using Jondo.Unity.World.Combat;
+using Xunit;
+
+namespace Jondo.Unity.Tests.Combat
+{
+    public class OsamodasEffectTests
+    {
+        [Fact]
+        public void Gobgob_uses_the_same_ground_summon_path_as_regular_summons()
+        {
+            Assert.True(EffectEngine.VaAlSuelo(EffectSupport.Summon));
+            Assert.True(EffectEngine.VaAlSuelo(EffectSupport.ControllableSummon));
+        }
+
+        [Theory]
+        [InlineData(EffectSupport.CasterCurrentHealthDamage)]
+        [InlineData(EffectSupport.CasterMissingHealthDamage)]
+        [InlineData(EffectSupport.BestElementDamage)]
+        public void Osamodas_special_damage_is_part_of_the_damage_pipeline(int effectId)
+            => Assert.True(EffectEngine.EsDeDano(effectId));
+
+        [Theory]
+        [InlineData(EffectSupport.Heal)]
+        [InlineData(EffectSupport.WaterHeal)]
+        [InlineData(EffectSupport.AirHeal)]
+        [InlineData(EffectSupport.EarthHeal)]
+        public void Every_elemental_Osamodas_heal_is_resolved_as_healing(int effectId)
+            => Assert.True(EffectEngine.EsCuraFija(effectId));
+    }
+}

--- a/Jondo.Unity.Tests/Combat/SummonTurnTests.cs
+++ b/Jondo.Unity.Tests/Combat/SummonTurnTests.cs
@@ -1,0 +1,58 @@
+using System.Linq;
+using Jondo.Unity.World.Fights;
+using Xunit;
+
+namespace Jondo.Unity.Tests.Combat
+{
+    public class SummonTurnTests
+    {
+        [Fact]
+        public void Active_summons_play_after_their_owner_while_passive_ones_stay_off_the_clock()
+        {
+            var fight = new FightInstance(1, 1);
+            var owner = new Fighter
+            {
+                Id = 10,
+                Initiative = 100,
+                MaxHP = 100,
+                CurrentHP = 100,
+            };
+            var enemy = new Fighter
+            {
+                Id = -1,
+                IsMonster = true,
+                Initiative = 50,
+                MaxHP = 100,
+                CurrentHP = 100,
+            };
+
+            fight.AddPlayer(owner);
+            fight.AddMonster(enemy);
+
+            var active = new Fighter
+            {
+                Id = -2,
+                IsMonster = true,
+                JuegaTurno = true,
+                MaxHP = 100,
+                CurrentHP = 100,
+                SpellIds = { 31166, 31168 },
+            };
+            var passive = new Fighter
+            {
+                Id = -3,
+                IsMonster = true,
+                JuegaTurno = false,
+                MaxHP = 100,
+                CurrentHP = 100,
+            };
+
+            fight.Invocar(active, owner);
+            fight.Invocar(passive, owner);
+
+            Assert.Equal(new long[] { owner.Id, active.Id, enemy.Id },
+                         fight.TurnOrder.Select(f => f.Id));
+            Assert.DoesNotContain(passive, fight.TurnOrder);
+        }
+    }
+}

--- a/Jondo.Unity.World/Combat/EffectSupport.cs
+++ b/Jondo.Unity.World/Combat/EffectSupport.cs
@@ -26,10 +26,9 @@ namespace Jondo.Unity.World.Combat
     /// </summary>
     /// <remarks>
     /// This is the information the architecture document calls the most useful thing in the whole
-    /// spell module, and the reason is effect 108 — healing. Its catalogue row carries no
-    /// characteristic, so it falls through to the panel-only branch: the spell card says the spell
-    /// heals, the animation plays, and nobody's life goes up. Nothing anywhere says so, and until
-    /// now the only way to know was to read <c>EffectEngine.cs</c>.
+    /// spell module. Effect 108 — healing — is the reason this list matters: its catalogue row
+    /// carries no characteristic, so it used to fall through to the panel-only branch even though
+    /// the spell card said that it healed. Keeping it here makes the implementation explicit.
     ///
     /// There are two ways an effect can work, and they are not the same:
     ///
@@ -72,6 +71,9 @@ namespace Jondo.Unity.World.Combat
         /// <summary>Summon a creature.</summary>
         public const int Summon = 181;
 
+        /// <summary>Heal a fixed amount, scaled by Intelligence and the Heals characteristic.</summary>
+        public const int Heal = 108;
+
         /// <summary>Heal a percentage of maximum life.</summary>
         public const int HealPercent = 1109;
 
@@ -103,7 +105,7 @@ namespace Jondo.Unity.World.Combat
             {
                 Push, Pull, StepBack, StepForward,
                 AddState, RemoveState,
-                CastSpell, Summon, HealPercent, Kill,
+                CastSpell, Summon, Heal, HealPercent, Kill,
             };
 
             for (int damage = FirstDamage; damage <= LastDamage; damage++) known.Add(damage);

--- a/Jondo.Unity.World/Combat/EffectSupport.cs
+++ b/Jondo.Unity.World/Combat/EffectSupport.cs
@@ -71,8 +71,22 @@ namespace Jondo.Unity.World.Combat
         /// <summary>Summon a creature.</summary>
         public const int Summon = 181;
 
+        /// <summary>
+        /// Summon a controllable creature. Osamodas' two Gobgob spells use this id instead of the
+        /// ordinary summon id; the creature still has to be created by the same fight code.
+        /// </summary>
+        public const int ControllableSummon = 1011;
+
+        /// <summary>Set the cooldown of the spell carried in DiceNum to Value rounds.</summary>
+        public const int SetCooldown = 1045;
+
         /// <summary>Heal a fixed amount, scaled by Intelligence and the Heals characteristic.</summary>
         public const int Heal = 108;
+
+        /// <summary>Elemental heals scale with Chance, Agility and Strength respectively.</summary>
+        public const int WaterHeal = 2998;
+        public const int AirHeal = 2999;
+        public const int EarthHeal = 3000;
 
         /// <summary>Heal a percentage of maximum life.</summary>
         public const int HealPercent = 1109;
@@ -84,6 +98,13 @@ namespace Jondo.Unity.World.Combat
         public const int FirstDamage = 91;
 
         public const int LastDamage = 100;
+
+        /// <summary>Neutral damage equal to a percentage of the caster's current/missing health.</summary>
+        public const int CasterCurrentHealthDamage = 89;
+        public const int CasterMissingHealthDamage = 279;
+
+        /// <summary>Damage in whichever elemental characteristic is highest on the caster.</summary>
+        public const int BestElementDamage = 2822;
 
         /// <summary>
         /// Category 2 is the weapon-only effects, which the catalogue path deliberately skips.
@@ -105,7 +126,9 @@ namespace Jondo.Unity.World.Combat
             {
                 Push, Pull, StepBack, StepForward,
                 AddState, RemoveState,
-                CastSpell, Summon, Heal, HealPercent, Kill,
+                CastSpell, Summon, ControllableSummon, SetCooldown,
+                Heal, WaterHeal, AirHeal, EarthHeal, HealPercent, Kill,
+                CasterCurrentHealthDamage, CasterMissingHealthDamage, BestElementDamage,
             };
 
             for (int damage = FirstDamage; damage <= LastDamage; damage++) known.Add(damage);

--- a/README.md
+++ b/README.md
@@ -218,7 +218,7 @@ One engine for all eighteen classes, driven entirely by client data. Not a singl
 - ✅ Summons as real fighters — own sheet, place in the carousel next to their owner, behaviour spell, lifetime, and they all fall when their summoner dies
 - ✅ Item attitudes — the six Dofus and the trophies grant their spell through effect 1175
 - ✅ The characteristic sheet in the shape the client expects: 53 entries in a fixed order, and a single-characteristic refresh **replaces** its entry rather than adding to it, so it repeats every field and puts the buff in its own slot `f8`
-- ❌ Healing — effect 108 is not wired; its catalogue row has `Characteristic = 0` and `Category = 2`, so it falls into the panel-only branch
+- ✅ Healing — effect 108 rolls once per cast, applies area falloff, Intelligence, flat Heals and received-healing multipliers, then caps the result to the target's missing life
 - ❌ Glyphs and traps (effects 400, 401, 1091)
 - ❌ Appearance-changing spells — the transform payload is an opaque blob, so the Cra's Sentinel works but does not change its look
 - ❌ Area shapes `G` (55 effects) and `*` (10), which fall back to the centre tile alone
@@ -361,11 +361,11 @@ is wrong. Four things it found, all measured:
   across 401 captures, 184 shows up on 420 elements and 114 on 23, every one a zaap. Our own log
   catches us emitting the pair `(type 0, skill 114)` 84 times — a pair that occurs zero times
   anywhere real. New passages declare 184
-- **647 of the game's 872 effects do nothing at all.** They are drawn on the spell card and the
-  engine has no code for them and no characteristic to apply — and **15,841 of the 34,823 spell
-  levels carry at least one**. The Studio ranks them by how many levels each one breaks, which turns
-  a curiosity into a work list: effect 1160 alone is on 6,709 levels, and healing — effect 108 — is
-  on 751
+- **The first audit found 647 of the game's 872 effects doing nothing at all.** They were drawn on
+  the spell card but had neither direct code nor a characteristic to apply, and **15,841 of the
+  34,823 spell levels carried at least one**. The Studio ranks them by how many levels each one
+  breaks, which turns a curiosity into a work list: effect 1160 alone is on 6,709 levels. Healing —
+  effect 108 — was one of those priorities with 751 levels and is now handled directly
 - **A monster's picture is filed under its `gfxId`, not its id.** Keyed by id, 847 of 5,134 found a
   picture and every one of those 847 was *somebody else's* creature. Keyed by gfxId it is 5,130
 

--- a/docs/world-editor.md
+++ b/docs/world-editor.md
@@ -261,9 +261,9 @@ motor que no tiene ni un hechizo escrito a mano: todo sale de los datos.
 
 **Falta.** Editar el `EffectsJson` con una interfaz en vez de a mano, y —lo realmente útil— una
 vista que diga **qué efectos sabe aplicar el motor y cuáles caen en la rama de «sólo para el
-panel»**. Hoy eso sólo se sabe leyendo `EffectEngine.cs`, y es la información que decide si un
-hechizo funciona de verdad. El efecto 108, la curación, es el ejemplo: parece que funciona y no cura
-a nadie.
+panel»**. La clasificación compartida de `EffectSupport` evita tener que deducirlo leyendo
+`EffectEngine.cs`. El efecto 108, la curación, fue el primer caso importante: el catálogo parecía
+válido pero no bastaba para aplicarlo, así que ahora figura como efecto directo.
 
 Un simulador —lanzar un hechizo contra un objetivo de prueba y ver las consecuencias sin montar un
 combate— vale más que el propio editor.


### PR DESCRIPTION
## Dependency
- depends on #26 for the fixed-healing pipeline used by elemental Osamodas heals
- after #26 is merged, this PR reduces to the two summon and Osamodas commits

## Summary
- load active summon spells from MonsterTemplates and insert those summons after their owner in turn order
- let summon AI move, heal allies and attack enemies with its available AP
- support controllable-summon and fixed-cooldown effects used by Esprit Glouton
- resolve Gobgob current-life, missing-life and best-element damage effects
- support the Water, Air and Earth Osamodas healing effects
- log exact AI skip reasons for missing data, AP, target, range and line of sight

## Validation
- 372 tests passed, 0 failed
- validated in game: Esprit Glouton summons template 8082, the Gobgob takes turns, attacks and kills targets
- validated in game: other Osamodas summons move, attack and heal