### PR TITLE
Keep the combat carousel in turn order

### DIFF
--- a/Jondo.Unity.Server/Handlers/FightHandler.cs
+++ b/Jondo.Unity.Server/Handlers/FightHandler.cs
@@ -513,12 +513,13 @@ namespace Jondo.Unity.Server.Handlers
                     Network.FightProtocol.BuildFightOption(option, fight.FightId)));
             }
 
-            var everyone = new List<long>();
-            foreach (var fighter in fight.Team0) everyone.Add(fighter.Id);
-            foreach (var fighter in fight.Team1) everyone.Add(fighter.Id);
+            // jzc identifies the current vignette by its index in this list. It must therefore be
+            // the exact engine turn order, not insertion order by team.
+            var everyone = CombatantsInTurnOrder(fight);
 
             await WriteFrameAsync(stream, ConnectionProtocol.Push(Op.Jzu,
                 Network.FightProtocol.BuildTeams(everyone)));
+            Program.LogDebug($"[FightHandler] jzu initial order: [{string.Join(",", everyone)}].");
 
             await WriteFrameAsync(stream, ConnectionProtocol.Push(Op.Jwq,
                 Network.FightProtocol.BuildPlacementDone()));
@@ -2436,12 +2437,30 @@ namespace Jondo.Unity.Server.Handlers
         /// </summary>
         private static async Task ReenviarLaListaAsync(NetworkStream stream, FightInstance fight)
         {
-            var todos = new List<long>();
-            foreach (var f in fight.Team0) if (f.IsAlive) todos.Add(f.Id);
-            foreach (var f in fight.Team1) if (f.IsAlive) todos.Add(f.Id);
+            var todos = CombatantsInTurnOrder(fight);
 
             await WriteFrameAsync(stream, ConnectionProtocol.Push(Op.Jzu,
                 Network.FightProtocol.BuildTeams(todos)));
+            Program.LogDebug($"[FightHandler] jzu refreshed order: [{string.Join(",", todos)}].");
+        }
+
+        /// <summary>
+        /// The list indexed by jzc's turn-position field. Keeping it as one helper prevents the
+        /// initial list and the list resent after a summon/death from drifting apart again.
+        /// </summary>
+        internal static List<long> CombatantsInTurnOrder(FightInstance fight)
+        {
+            var result = fight.TurnOrder.Where(f => f.IsAlive).Select(f => f.Id).ToList();
+            var present = new HashSet<long>(result);
+
+            // A passive summon has no turn index but still has to remain registered client-side.
+            // Put such board actors after every indexed turn fighter so they cannot shift jzc's
+            // positions while remaining visible and targetable.
+            foreach (var fighter in fight.Team0.Concat(fight.Team1))
+            {
+                if (fighter.IsAlive && present.Add(fighter.Id)) result.Add(fighter.Id);
+            }
+            return result;
         }
 
         /// <summary>

--- a/Jondo.Unity.Tests/Combat/CombatTurnCarouselTests.cs
+++ b/Jondo.Unity.Tests/Combat/CombatTurnCarouselTests.cs
@@ -1,0 +1,44 @@
+using System.Linq;
+using Jondo.Unity.Server.Handlers;
+using Jondo.Unity.World.Fights;
+using Xunit;
+
+namespace Jondo.Unity.Tests.Combat
+{
+    public class CombatTurnCarouselTests
+    {
+        [Fact]
+        public void Carousel_uses_engine_turn_order_and_appends_passive_summons()
+        {
+            var fight = new FightInstance(1, 1);
+            var player = FighterWith(10, 400);
+            var secondPlayer = FighterWith(11, 100);
+            var monster = FighterWith(-1, 500, true);
+            var secondMonster = FighterWith(-2, 300, true);
+
+            fight.AddPlayer(player);
+            fight.AddPlayer(secondPlayer);
+            fight.AddMonster(monster);
+            fight.AddMonster(secondMonster);
+
+            var passive = FighterWith(-3, 0, true);
+            passive.JuegaTurno = false;
+            fight.Invocar(passive, player);
+
+            Assert.Equal(new long[] { -1, 10, -2, 11 },
+                         fight.TurnOrder.Select(fighter => fighter.Id));
+            Assert.Equal(new long[] { -1, 10, -2, 11, -3 },
+                         FightHandler.CombatantsInTurnOrder(fight));
+        }
+
+        private static Fighter FighterWith(long id, int initiative, bool monster = false)
+            => new Fighter
+            {
+                Id = id,
+                Initiative = initiative,
+                IsMonster = monster,
+                MaxHP = 100,
+                CurrentHP = 100,
+            };
+    }
+}


### PR DESCRIPTION
## Summary
- build initial and refreshed jzu fighter lists from the engine turn order
- keep passive summons visible by appending them after fighters that own a turn index
- prevent jzc carousel indexes from pointing at a different fighter after summons or deaths
- add regression coverage for alternating teams and passive summons

## Validation
- 343 tests passed, 0 failed
- validated in game across summons and deaths: the displayed carousel follows the actual turns