### PR TITLE
Evitar casillas bloqueadas al salir de combate

### DIFF
--- a/Jondo.Unity.Server/Handlers/FightHandler.cs
+++ b/Jondo.Unity.Server/Handlers/FightHandler.cs
@@ -54,6 +54,12 @@ namespace Jondo.Unity.Server.Handlers
                 if (esSuyo) _activeFights.TryRemove(par.Key, out _);
             }
 
+            // Save the roleplay location before GameState is moved to an arena placement cell.
+            // The previous code saved fight.Team0[0].CellId later, so arena cell 177 was restored
+            // on roleplay map 197918724 even though that cell is not walkable there.
+            var sessionState = Network.SessionContext.State;
+            RememberRoleplayReturn(sessionState, mapId, sessionState.CellId);
+
             GameState.IsInFight = true;
             GameState.CurrentFightMobId = mobGroup.MobId;
 
@@ -250,12 +256,6 @@ namespace Jondo.Unity.Server.Handlers
             GameState.CellId = fight.Team0.Count > 0 ? fight.Team0[0].CellId : GameState.CellId;
             fight.HasLoadedMap = false;
 
-            // De dónde se salió, para poder volver. El mapa de combate es de instancia y no vale
-            // como sitio donde dejar al personaje.
-            var suyo = Network.SessionContext.State;
-            suyo.RoleplayMapId = fight.RoleplayMapId;
-            suyo.RoleplayCellId = fight.Team0.Count > 0 ? fight.Team0[0].CellId : 0;
-
             // Sin guardar el personaje: el mapa de combate es un mapa de instancia y dejarlo escrito
             // en la ficha lo devolvería ahí al volver a entrar, a un sitio del que no se sale.
             //
@@ -366,8 +366,12 @@ namespace Jondo.Unity.Server.Handlers
 
             suyo.IsInFight = false;
             suyo.MapId = suyo.RoleplayMapId;
-            if (suyo.RoleplayCellId != 0) suyo.CellId = suyo.RoleplayCellId;
+            int storedCell = suyo.RoleplayCellId;
+            suyo.CellId = SafeRoleplayReturnCell(suyo.RoleplayMapId, storedCell);
             DatabaseManager.SaveCurrentCharacter();
+
+            Program.LogDebug($"[Fight] Returning character {suyo.CharacterId} to roleplay map " +
+                             $"{suyo.MapId}, cell {suyo.CellId} (stored cell {storedCell}).");
 
             suyo.RoleplayMapId = 0;
             suyo.RoleplayCellId = 0;
@@ -384,6 +388,28 @@ namespace Jondo.Unity.Server.Handlers
             }
 
             Program.LogDebug("[Combate] Fuera del combate; el personaje vuelve al mapa de superficie.");
+        }
+
+        /// <summary>
+        /// Stores the surface location before the session is moved into its fight arena.
+        /// </summary>
+        internal static void RememberRoleplayReturn(SessionState state, long mapId, int cellId)
+        {
+            state.RoleplayMapId = mapId;
+            state.RoleplayCellId = SafeRoleplayReturnCell(mapId, cellId);
+
+            if (state.RoleplayCellId != cellId)
+            {
+                Program.LogDebug($"[Fight] Roleplay cell {cellId} is not walkable on map {mapId}; " +
+                                 $"return cell {state.RoleplayCellId} was stored instead.");
+            }
+        }
+
+        /// <summary>Returns a valid surface cell, falling back near the map centre.</summary>
+        internal static int SafeRoleplayReturnCell(long mapId, int cellId)
+        {
+            int target = cellId is >= 0 and <= 559 ? cellId : TeleportHandler.MapCentre;
+            return MapManager.GetNearestWalkableCell(mapId, target);
         }
 
         /// <summary>

--- a/Jondo.Unity.Tests/Combat/FightReturnCellTests.cs
+++ b/Jondo.Unity.Tests/Combat/FightReturnCellTests.cs
@@ -1,0 +1,58 @@
+using Jondo.Unity.Server;
+using Jondo.Unity.Server.Handlers;
+using Jondo.Unity.Server.Managers;
+using Xunit;
+
+namespace Jondo.Unity.Tests.Combat
+{
+    public class FightReturnCellTests
+    {
+        [Fact]
+        public void Entering_an_arena_keeps_the_surface_cell_instead_of_the_placement_cell()
+        {
+            const long mapId = 991_000_001;
+            WithWalkableCells(mapId, new[] { 176, 190 }, () =>
+            {
+                var state = new SessionState { MapId = mapId, CellId = 176 };
+
+                FightHandler.RememberRoleplayReturn(state, state.MapId, state.CellId);
+                state.MapId = 992_000_001;
+                state.CellId = 177;
+
+                Assert.Equal(mapId, state.RoleplayMapId);
+                Assert.Equal(176, state.RoleplayCellId);
+            });
+        }
+
+        [Fact]
+        public void An_invalid_surface_cell_is_replaced_by_the_nearest_walkable_one()
+        {
+            const long mapId = 991_000_002;
+            WithWalkableCells(mapId, new[] { 176, 190 }, () =>
+            {
+                Assert.Equal(176, FightHandler.SafeRoleplayReturnCell(mapId, 177));
+            });
+        }
+
+        private static void WithWalkableCells(long mapId, int[] cells, Action assertion)
+        {
+            bool existed = MapManager.WalkableCells.TryGetValue(mapId, out var previous);
+            MapManager.WalkableCells[mapId] = cells.ToList();
+            try
+            {
+                assertion();
+            }
+            finally
+            {
+                if (existed)
+                {
+                    MapManager.WalkableCells[mapId] = previous!;
+                }
+                else
+                {
+                    MapManager.WalkableCells.Remove(mapId);
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION
## Qué corrige

- Conserva el mapa y la casilla de superficie antes de sustituirlos por la colocación de la arena.
- Comprueba la casilla contra los datos transitables del mapa de rol y, si no lo es, escoge la más cercana.
- Vuelve a validar la casilla al terminar el combate y deja en el registro la casilla guardada y la restaurada.

Antes se guardaba después de mover al personaje a la arena. Una casilla válida en combate podía no ser transitable en el mapa de superficie y dejar al personaje bloqueado.

## Pruebas

- `FightReturnCellTests`: 2/2.
- Solución completa sobre `main`: 494/494.
- Prueba real en VPS, mapa `191104002`:
  - casilla de superficie `365` detectada como no transitable;
  - sustitución y retorno en `366`, confirmada transitable;
  - combate siguiente: retorno y actor enviados en `340`, también transitable;
  - las antiguas casillas problemáticas `365` y `203` constan como no transitables.

## Alcance

Un commit, dos archivos: implementación y pruebas de regresión.