### PR TITLE
Rechazar invocaciones al límite antes de gastar PA

### DIFF
--- a/Jondo.Unity.Server/Handlers/FightHandler.cs
+++ b/Jondo.Unity.Server/Handlers/FightHandler.cs
@@ -824,6 +824,7 @@ namespace Jondo.Unity.Server.Handlers
         private static List<(int Characteristic, long Base, long Gear)> FullSheetOf(Fighter fighter,
                                                                                    bool conTraza = true)
         {
+            var summonCharacteristic = SummonCharacteristicFor(fighter);
             var ficha = new List<(int, long, long)>
             {
                 (ActionPointsCharacteristic, fighter.MaxAP, 0),
@@ -873,7 +874,9 @@ namespace Jondo.Unity.Server.Handlers
                 (18, 0, fighter.CriticalBonus),
                 (19, 0, fighter.Range),
                 (25, 0, fighter.Power),
-                (26, 0, fighter.Otra(26)), (50, 0, fighter.Otra(50)), (75, 10, fighter.Otra(75)),
+                (CaracteristicaDeInvocaciones, summonCharacteristic.Base,
+                 summonCharacteristic.Gear),
+                (50, 0, fighter.Otra(50)), (75, 10, fighter.Otra(75)),
                 // Aquí iba la 84, el daño de empuje. El servidor real NO LA MANDA: su ficha
                 // tiene 53 entradas y la 84 no está en ninguna, mientras que la 85 —la
                 // resistencia al empuje— sí. Y la metíamos justo en la posición 33, que es donde
@@ -2166,7 +2169,17 @@ namespace Jondo.Unity.Server.Handlers
                                  $"{ConBonos(caster, CriticoCaracteristica, 0, fight.RoundNumber)} del personaje).");
             }
 
-            caster.CurrentAP -= cost;
+            // The capacity refusal and AP mutation stay in one tested operation. Previously the
+            // capacity guard ran much later, when the effect was applied and AP was already gone.
+            IEnumerable<SpellEffect> castEffects = spell == 0
+                ? Array.Empty<SpellEffect>()
+                : Managers.EffectEngine.EfectosDeLaTirada(spell, grade, critico);
+            if (!await TryPayCastCostAsync(
+                    fight, caster, castEffects, cost,
+                    packet => WriteFrameAsync(stream, packet)))
+            {
+                return;
+            }
 
             caster.LanzadosEsteTurno[spell] = esteTurno + 1;
             if (aQuien != 0) caster.LanzadosPorObjetivo[(spell, aQuien)] = sobreEse + 1;
@@ -2253,14 +2266,16 @@ namespace Jondo.Unity.Server.Handlers
                 return;
             }
 
-            // Cuántas puede llevar a la vez: la característica 26, que el cliente pinta como
-            // "Invocación" en el panel. Sale de la base más el equipo, como todo lo demás.
-            int tope = TopeDeInvocaciones(quienInvoca, fight.RoundNumber);
-            int puestas = CuantasLleva(fight, quienInvoca);
-            if (tope > 0 && puestas >= tope)
+            // Keep a defensive check for delayed or chained summon effects. Immediate casts have
+            // already crossed the preflight in CastAsync, before paying AP.
+            int limit = SummonLimitFor(quienInvoca, fight.RoundNumber);
+            int active = ActiveSummonCount(fight, quienInvoca);
+            if (limit > 0 && active >= limit)
             {
-                Program.LogDebug($"[Combate] {quienInvoca.Id} ya lleva {puestas} invocación(es) y su " +
-                                 $"tope es {tope}; no se invoca la plantilla {plantilla}.");
+                await SendSummonLimitWarningAsync(
+                    packet => WriteFrameAsync(stream, packet), limit);
+                Program.LogDebug($"[Fight] Fighter {quienInvoca.Id} already controls {active} " +
+                                 $"summon(s), at capacity {limit}; template {plantilla} was not summoned.");
                 return;
             }
 
@@ -2432,33 +2447,89 @@ namespace Jondo.Unity.Server.Handlers
                 Network.FightProtocol.BuildTeams(todos)));
         }
 
-        /// <summary>La característica 26, que el cliente pinta como "Invocación" en el panel.</summary>
+        /// <summary>Characteristic 26, displayed as summon capacity by the client.</summary>
         private const int CaracteristicaDeInvocaciones = 26;
 
+        /// <summary>Every player can control one summon before equipment and buffs.</summary>
+        internal const int BasePlayerSummonLimit = 1;
+
         /// <summary>
-        /// Cuántas invocaciones puede llevar uno a la vez: lo suyo de siempre más lo que le den el
-        /// equipo y los embrujos. Para el jugador sale de la ficha; para un monstruo, de lo que
-        /// traiga su plantilla.
+        /// Splits the innate player point from equipment in the same base/gear columns used by
+        /// the rest of the combat sheet. Monsters keep the value supplied by their template. The
+        /// capture named in the review is not present in this checkout, so this is an explicit
+        /// protocol inference rather than a capture-backed field observation.
         /// </summary>
-        private static int TopeDeInvocaciones(Fighter quien, int ronda)
+        internal static (long Base, long Gear) SummonCharacteristicFor(Fighter fighter)
+            => fighter.IsMonster
+                ? (0, fighter.Otra(CaracteristicaDeInvocaciones))
+                : (BasePlayerSummonLimit, fighter.Otra(CaracteristicaDeInvocaciones));
+
+        /// <summary>
+        /// Returns the simultaneous summon capacity. Player equipment is already stored in
+        /// Otras[26] by RellenarLaFicha, so reading StatsHandler again would count it twice.
+        /// </summary>
+        internal static int SummonLimitFor(Fighter fighter, int round)
         {
-            int suyo = quien.Otra(CaracteristicaDeInvocaciones);
-            if (!quien.IsMonster)
-            {
-                suyo += StatsHandler.GetEquipBonus(CaracteristicaDeInvocaciones);
-            }
-            return Math.Max(0, suyo + quien.Buffs.De(CaracteristicaDeInvocaciones, ronda));
+            int innate = fighter.IsMonster ? 0 : BasePlayerSummonLimit;
+            int equipmentOrTemplate = fighter.Otra(CaracteristicaDeInvocaciones);
+            int buffs = fighter.Buffs.De(CaracteristicaDeInvocaciones, round);
+            return Math.Max(0, innate + equipmentOrTemplate + buffs);
         }
 
-        /// <summary>Las que tiene ahora mismo en el tablero.</summary>
-        private static int CuantasLleva(FightInstance fight, Fighter quien)
+        /// <summary>Counts this fighter's living summons currently present on the board.</summary>
+        internal static int ActiveSummonCount(FightInstance fight, Fighter owner)
         {
-            int cuantas = 0;
+            int active = 0;
             foreach (var f in TodosLosCombatientes(fight))
             {
-                if (f.EsInvocado && f.IsAlive && f.Invocador == quien.Id) cuantas++;
+                if (f.EsInvocado && f.IsAlive && f.Invocador == owner.Id) active++;
             }
-            return cuantas;
+            return active;
+        }
+
+        /// <summary>
+        /// Pays a cast only after an immediate summon has passed its capacity check. Keeping the
+        /// check and the AP mutation in this method makes their ordering structural and testable.
+        /// </summary>
+        internal static async Task<bool> TryPayCastCostAsync(
+            FightInstance fight,
+            Fighter caster,
+            IEnumerable<SpellEffect> effects,
+            int cost,
+            Func<byte[], Task> sendAsync)
+        {
+            bool summonsImmediately = effects.Any(effect =>
+                effect.EffectId == Jondo.Unity.World.Combat.EffectSupport.Summon &&
+                effect.DiceNum > 0 &&
+                effect.Disparadores().Any(trigger =>
+                    string.Equals(trigger, Managers.EffectEngine.AlLanzar,
+                                  StringComparison.OrdinalIgnoreCase)));
+
+            if (summonsImmediately)
+            {
+                int limit = SummonLimitFor(caster, fight.RoundNumber);
+                int active = ActiveSummonCount(fight, caster);
+                if (limit > 0 && active >= limit)
+                {
+                    await SendSummonLimitWarningAsync(sendAsync, limit);
+                    Program.LogDebug($"[Fight] Fighter {caster.Id} cannot cast a summon: " +
+                                     $"{active} active summon(s), capacity {limit}.");
+                    return false;
+                }
+            }
+
+            caster.CurrentAP -= cost;
+            return true;
+        }
+
+        private static Task SendSummonLimitWarningAsync(Func<byte[], Task> sendAsync, int limit)
+        {
+            byte[] packet = ConnectionProtocol.Push(Op.Lqn,
+                ConnectionProtocol.BuildInfoMessage(
+                    InfoMessages.Warning,
+                    InfoMessages.SummonLimitReached,
+                    limit.ToString(System.Globalization.CultureInfo.InvariantCulture)));
+            return sendAsync(packet);
         }
 
         /// <summary>

--- a/Jondo.Unity.Server/Managers/InfoMessages.cs
+++ b/Jondo.Unity.Server/Managers/InfoMessages.cs
@@ -62,6 +62,9 @@ namespace Jondo.Unity.Server.Managers
         /// <summary>«No tienes el nivel de oficio necesario.» Va con <see cref="Warning"/>.</summary>
         public const int JobLevelTooLow = 284;
 
+        /// <summary>Summon capacity reached. Parameter 0 is the current capacity.</summary>
+        public const int SummonLimitReached = 203;
+
         private static readonly Dictionary<(int Type, int Id), string> _texts = new();
 
         public static int Count => _texts.Count;

--- a/Jondo.Unity.Tests/Combat/SummonCapacityTests.cs
+++ b/Jondo.Unity.Tests/Combat/SummonCapacityTests.cs
@@ -1,0 +1,101 @@
+using Jondo.Unity.Protocol;
+using Jondo.Unity.Server.Handlers;
+using Jondo.Unity.Server.Managers;
+using Jondo.Unity.Server.Network;
+using Jondo.Unity.World.Combat;
+using Jondo.Unity.World.Fights;
+using Xunit;
+
+namespace Jondo.Unity.Tests.Combat
+{
+    public class SummonCapacityTests
+    {
+        [Fact]
+        public async Task A_summon_at_capacity_is_rejected_before_AP_is_spent_and_warns_the_client()
+        {
+            var fight = new FightInstance(1, 1);
+            var caster = new Fighter { Id = 10, CurrentHP = 100, CurrentAP = 6 };
+            fight.AddPlayer(caster);
+            fight.AddPlayer(new Fighter
+            {
+                Id = -2,
+                CurrentHP = 100,
+                Invocador = caster.Id,
+            });
+
+            var summonEffect = new SpellEffect
+            {
+                EffectId = EffectSupport.Summon,
+                DiceNum = 123,
+                Triggers = EffectEngine.AlLanzar,
+            };
+            var sent = new List<byte[]>();
+
+            bool paid = await FightHandler.TryPayCastCostAsync(
+                fight, caster, new[] { summonEffect }, cost: 3,
+                packet =>
+                {
+                    sent.Add(packet);
+                    return Task.CompletedTask;
+                });
+
+            Assert.False(paid);
+            Assert.Equal(6, caster.CurrentAP);
+            Assert.Single(sent);
+            Assert.Equal(
+                ConnectionProtocol.Push(Op.Lqn,
+                    ConnectionProtocol.BuildInfoMessage(
+                        InfoMessages.Warning,
+                        InfoMessages.SummonLimitReached,
+                        FightHandler.BasePlayerSummonLimit.ToString())),
+                sent[0]);
+        }
+
+        [Fact]
+        public void Player_capacity_combines_base_equipment_and_buffs_once()
+        {
+            var fighter = new Fighter { Id = 10 };
+            fighter.Otras[26] = 3;
+            fighter.Buffs.Poner(new Buff
+            {
+                EffectId = 1,
+                EffectUid = 1,
+                Caracteristica = 26,
+                Cuanto = 2,
+                EmpiezaEnRonda = 0,
+                CaducaEnRonda = -1,
+                Quien = fighter.Id,
+            }, () => 1);
+
+            Assert.Equal((1L, 3L), FightHandler.SummonCharacteristicFor(fighter));
+            Assert.Equal(6, FightHandler.SummonLimitFor(fighter, round: 0));
+        }
+
+        [Fact]
+        public async Task A_summon_below_capacity_pays_its_AP_normally()
+        {
+            var fight = new FightInstance(1, 1);
+            var caster = new Fighter { Id = 10, CurrentHP = 100, CurrentAP = 6 };
+            fight.AddPlayer(caster);
+            var summonEffect = new SpellEffect
+            {
+                EffectId = EffectSupport.Summon,
+                DiceNum = 123,
+                Triggers = EffectEngine.AlLanzar,
+            };
+            var sent = new List<byte[]>();
+
+            bool paid = await FightHandler.TryPayCastCostAsync(
+                fight, caster, new[] { summonEffect }, cost: 3,
+                packet =>
+                {
+                    sent.Add(packet);
+                    return Task.CompletedTask;
+                });
+
+            Assert.True(paid);
+            Assert.Equal(3, caster.CurrentAP);
+            Assert.Empty(sent);
+        }
+    }
+}


### PR DESCRIPTION
## Resumen

- Da a los jugadores una capacidad base de una invocación y suma equipo y efectos temporales una sola vez.
- Comprueba los efectos de invocación inmediatos antes de descontar PA.
- Rechaza tanto las invocaciones normales como las controlables cuando la capacidad está llena.
- Envía el aviso de información 203 con la capacidad actual y conserva una comprobación defensiva para efectos encadenados o diferidos.
- Añade regresiones para rechazo sin gasto, capacidad combinada y lanzamiento permitido.

## Motivo

El límite anterior se comprobaba al aplicar el efecto, después de descontar los PA. Cuando el personaje alcanzaba su capacidad, el hechizo no creaba nada pero los PA ya habían desaparecido y el cliente no recibía ninguna explicación.

El estado visual gris del icono no forma parte de esta PR: no hay una captura que identifique un paquete de disponibilidad por capacidad y `jxc` representa recargas, no este límite.

## Pruebas

- `SummonCapacityTests`: 3/3.
- Suite completa sobre el `main` oficial actual: 499/499.
- Prueba real: primera invocación 10→7 PA; tres intentos posteriores rechazados con capacidad 1; el siguiente hechizo de 2 PA dejó 5 PA, confirmando que los rechazos no gastaron ninguno.