### PR TITLE
Mantener el carrusel sincronizado tras las muertes

### DIFF
--- a/Jondo.Unity.Server/Handlers/FightHandler.cs
+++ b/Jondo.Unity.Server/Handlers/FightHandler.cs
@@ -1714,7 +1714,7 @@ namespace Jondo.Unity.Server.Handlers
 
             await WriteFrameAsync(stream, ConnectionProtocol.Push(Op.Jzc,
                 Network.FightProtocol.BuildTurnStart(fighter.Id, duration,
-                                                     fight.CurrentTurnIndex, fight.RoundNumber)));
+                                                     CarouselTurnIndex(fight), fight.RoundNumber)));
 
             // Los invocados a los que se les ha acabado el tiempo se deshacen aquí, al principio
             // del turno, que es cuando lo hace el servidor real: en la captura la baliza sale en
@@ -2424,12 +2424,50 @@ namespace Jondo.Unity.Server.Handlers
         /// </summary>
         private static async Task ReenviarLaListaAsync(NetworkStream stream, FightInstance fight)
         {
-            var todos = new List<long>();
-            foreach (var f in fight.Team0) if (f.IsAlive) todos.Add(f.Id);
-            foreach (var f in fight.Team1) if (f.IsAlive) todos.Add(f.Id);
+            var todos = CombatantsInTurnOrder(fight);
 
             await WriteFrameAsync(stream, ConnectionProtocol.Push(Op.Jzu,
                 Network.FightProtocol.BuildTeams(todos)));
+            Program.LogDebug($"[Fight] Refreshed carousel order: [{string.Join(",", todos)}].");
+        }
+
+        /// <summary>
+        /// Builds the live combat carousel in engine turn order. Passive summons remain visible
+        /// and targetable but are appended because they never receive a jzc turn index.
+        /// </summary>
+        internal static List<long> CombatantsInTurnOrder(FightInstance fight)
+        {
+            var result = fight.TurnOrder.Where(fighter => fighter.IsAlive)
+                                        .Select(fighter => fighter.Id)
+                                        .ToList();
+            var present = new HashSet<long>(result);
+
+            foreach (var fighter in fight.Team0.Concat(fight.Team1))
+            {
+                if (fighter.IsAlive && present.Add(fighter.Id)) result.Add(fighter.Id);
+            }
+
+            return result;
+        }
+
+        /// <summary>
+        /// Returns f7 for jzc in the same filtered prefix emitted by CombatantsInTurnOrder. The
+        /// engine keeps corpses in TurnOrder, so CurrentTurnIndex cannot be sent after a death.
+        /// </summary>
+        internal static int CarouselTurnIndex(FightInstance fight)
+        {
+            var current = fight.CurrentFighter;
+            if (current == null) return 0;
+
+            int index = 0;
+            foreach (var fighter in fight.TurnOrder)
+            {
+                if (!fighter.IsAlive) continue;
+                if (fighter == current) return index;
+                index++;
+            }
+
+            return 0;
         }
 
         /// <summary>La característica 26, que el cliente pinta como "Invocación" en el panel.</summary>

--- a/Jondo.Unity.Tests/Combat/CombatTurnCarouselTests.cs
+++ b/Jondo.Unity.Tests/Combat/CombatTurnCarouselTests.cs
@@ -1,0 +1,65 @@
+using Jondo.Unity.Server.Handlers;
+using Jondo.Unity.World.Fights;
+using Xunit;
+
+namespace Jondo.Unity.Tests.Combat
+{
+    public class CombatTurnCarouselTests
+    {
+        [Fact]
+        public void Death_ahead_of_the_current_fighter_keeps_jzc_index_inside_the_refreshed_list()
+        {
+            var fight = FightWithFasterAndSlowerMonsters();
+            fight.StartFight();
+            fight.NextTurn();
+
+            Assert.Equal(10, fight.CurrentFighter.Id);
+            Assert.Equal(1, fight.CurrentTurnIndex);
+
+            fight.Team1.Single(fighter => fighter.Id == -1).CurrentHP = 0;
+
+            Assert.Equal(new long[] { 10, -2 }, FightHandler.CombatantsInTurnOrder(fight));
+            Assert.Equal(0, FightHandler.CarouselTurnIndex(fight));
+
+            fight.NextTurn();
+
+            Assert.Equal(-2, fight.CurrentFighter.Id);
+            Assert.Equal(1, FightHandler.CarouselTurnIndex(fight));
+        }
+
+        [Fact]
+        public void Passive_summons_are_appended_without_shifting_turn_indexes()
+        {
+            var fight = FightWithFasterAndSlowerMonsters();
+            var player = fight.Team0.Single();
+            var passive = FighterWith(-3, initiative: 0, monster: true);
+            passive.JuegaTurno = false;
+            fight.Invocar(passive, player);
+            fight.StartFight();
+            fight.NextTurn();
+
+            Assert.Equal(new long[] { -1, 10, -2, -3 },
+                         FightHandler.CombatantsInTurnOrder(fight));
+            Assert.Equal(1, FightHandler.CarouselTurnIndex(fight));
+        }
+
+        private static FightInstance FightWithFasterAndSlowerMonsters()
+        {
+            var fight = new FightInstance(1, 1);
+            fight.AddPlayer(FighterWith(10, initiative: 400));
+            fight.AddMonster(FighterWith(-1, initiative: 500, monster: true));
+            fight.AddMonster(FighterWith(-2, initiative: 300, monster: true));
+            return fight;
+        }
+
+        private static Fighter FighterWith(long id, int initiative, bool monster = false)
+            => new Fighter
+            {
+                Id = id,
+                Initiative = initiative,
+                IsMonster = monster,
+                MaxHP = 100,
+                CurrentHP = 100,
+            };
+    }
+}


### PR DESCRIPTION
## Resumen
- construye el carrusel con los combatientes vivos en el orden real de turnos
- recalcula el índice enviado en `jzc` después de una muerte, sin contar cadáveres
- mantiene visibles al final las invocaciones pasivas que no reciben turno

## Pruebas
- `CombatTurnCarouselTests`: 2/2
- suite completa: 501/501
- validación manual en el cliente: el retrato activo, las invocaciones y la retirada de muertos permanecen sincronizados