### PR TITLE
Liberar lanzamientos de cliente bloqueados

### DIFF
--- a/Jondo.Unity.Server/Network/ClientLaunchRegistry.cs
+++ b/Jondo.Unity.Server/Network/ClientLaunchRegistry.cs
@@ -167,7 +167,29 @@ namespace Jondo.Unity.Server.Network
         /// </summary>
         public static void RemoveByAccount(long accountId)
         {
-            if (ByAccount.TryGetValue(accountId, out var launch)) Remove(launch);
+            lock (RegistrationGate)
+            {
+                if (ByAccount.TryGetValue(accountId, out var launch)) Remove(launch);
+            }
+        }
+
+        /// <summary>
+        /// Releases the launch owned by a game socket that has just disconnected. The instance
+        /// check prevents an old socket from deleting a newer relaunch of the same account.
+        /// </summary>
+        public static bool TryRemoveDisconnected(long accountId, int launchInstanceId)
+        {
+            if (accountId <= 0 || launchInstanceId <= 0) return false;
+
+            lock (RegistrationGate)
+            {
+                if (!ByAccount.TryGetValue(accountId, out var launch)
+                    || launch.InstanceId != launchInstanceId)
+                    return false;
+
+                Remove(launch);
+                return true;
+            }
         }
 
         /// <summary>Las cuentas que tienen un cliente abierto ahora mismo.</summary>
@@ -190,13 +212,11 @@ namespace Jondo.Unity.Server.Network
                 var launch = pair.Value;
                 if (ahora - launch.CreatedAtUtc < cuanto) continue;
 
-                // Si ya está jugando de verdad no se toca: tiene sesión de juego abierta.
-                bool jugando = false;
-                foreach (var suya in ByGameSession)
-                {
-                    if (ReferenceEquals(suya.Value, launch)) { jugando = true; break; }
-                }
-                if (jugando) continue;
+                // A Zaap gameSession only proves that the first handshake happened. The client
+                // can disappear while opening its second connection and never present a ticket;
+                // only a bound game socket is a live client that must be preserved.
+                if (SessionRegistry.HasConnectedLaunch(launch.AccountId, launch.InstanceId))
+                    continue;
 
                 Remove(launch);
                 soltados++;

--- a/Jondo.Unity.Server/Network/GameNodeProxy.cs
+++ b/Jondo.Unity.Server/Network/GameNodeProxy.cs
@@ -1095,7 +1095,8 @@ namespace Jondo.Unity.Server.Network
 
                 accountId = session.AccountId;
                 serverId = session.ServerId;
-                SessionContext.Current.BindAccount(accountId, serverId, session.Language);
+                SessionContext.Current.BindAccount(
+                    accountId, serverId, session.Language, session.LaunchInstanceId);
                 return true;
             }
             catch (Exception ex)

--- a/Jondo.Unity.Server/Network/GameServerProxy.cs
+++ b/Jondo.Unity.Server/Network/GameServerProxy.cs
@@ -269,7 +269,9 @@ namespace Jondo.Unity.Server.Network
                                 ? lanzamiento.Language
                                 : lang;
 
-                            var ticket = SessionRegistry.Issue(accountId, selectedServerId, idioma);
+                            int launchInstanceId = lanzamiento?.InstanceId ?? 0;
+                            var ticket = SessionRegistry.Issue(
+                                accountId, selectedServerId, idioma, launchInstanceId);
 
                             byte[] response = ConnectionProtocol.BuildServerSelected(
                                 lang, ticket.Value, "127.0.0.1", Program.gamePort, Program.gamePort);

--- a/Jondo.Unity.Server/Network/GameSession.cs
+++ b/Jondo.Unity.Server/Network/GameSession.cs
@@ -48,6 +48,7 @@ namespace Jondo.Unity.Server.Network
         public SessionState State { get; } = new SessionState();
         public long AccountId { get; private set; }
         public int ServerId { get; private set; }
+        public int LaunchInstanceId { get; private set; }
         public long CharacterId => State.CharacterId;
         public long MapId => State.MapId;
         public bool IsAuthenticated => AccountId > 0;
@@ -63,11 +64,13 @@ namespace Jondo.Unity.Server.Network
                 ? Task.CompletedTask
                 : Jondo.Protocol.NetworkMessage.WriteFrameAsync(Stream, packet);
 
-        public void BindAccount(long accountId, int serverId, string language = "es")
+        public void BindAccount(long accountId, int serverId, string language = "es",
+                                int launchInstanceId = 0)
         {
             if (accountId <= 0) throw new ArgumentOutOfRangeException(nameof(accountId));
             AccountId = accountId;
             ServerId = serverId;
+            LaunchInstanceId = launchInstanceId;
             State.Language = string.IsNullOrWhiteSpace(language) ? "es" : language;
         }
 

--- a/Jondo.Unity.Server/Network/SessionRegistry.cs
+++ b/Jondo.Unity.Server/Network/SessionRegistry.cs
@@ -31,6 +31,7 @@ namespace Jondo.Unity.Server.Network
             public long AccountId { get; init; }
             public int ServerId { get; init; }
             public string Language { get; init; } = "es";
+            public int LaunchInstanceId { get; init; }
             public DateTime Created { get; init; }
         }
 
@@ -56,13 +57,30 @@ namespace Jondo.Unity.Server.Network
             }
         }
 
-        public static bool Unregister(GameSession session) => _sessions.TryRemove(session.Id, out _);
+        public static bool Unregister(GameSession session)
+        {
+            bool removed = _sessions.TryRemove(session.Id, out _);
+            if (ClientLaunchRegistry.TryRemoveDisconnected(
+                    session.AccountId, session.LaunchInstanceId))
+            {
+                Program.LogDebug($"[Sessions] Account {session.AccountId} launch " +
+                                 $"{session.LaunchInstanceId} released after its game socket closed.");
+            }
+            return removed;
+        }
 
         public static bool TryGet(Guid sessionId, out GameSession? session)
             => _sessions.TryGetValue(sessionId, out session);
 
         public static GameSession? FindByCharacter(long characterId)
             => _sessions.Values.FirstOrDefault(s => s.CharacterId == characterId);
+
+        /// <summary>Whether a launch has reached an authenticated game socket.</summary>
+        public static bool HasConnectedLaunch(long accountId, int launchInstanceId)
+            => accountId > 0 && launchInstanceId > 0
+               && _sessions.Values.Any(session =>
+                   session.AccountId == accountId
+                   && session.LaunchInstanceId == launchInstanceId);
 
         /// <summary>
         /// El personaje conectado que se llama asi. Hace falta para los susurros: el cliente
@@ -180,7 +198,8 @@ namespace Jondo.Unity.Server.Network
         }
 
         /// <summary>Creates a new ticket for a specific account, server and client language.</summary>
-        public static Ticket Issue(long accountId, int serverId, string language = "es")
+        public static Ticket Issue(long accountId, int serverId, string language = "es",
+                                   int launchInstanceId = 0)
         {
             Purge();
 
@@ -197,6 +216,7 @@ namespace Jondo.Unity.Server.Network
                 AccountId = accountId,
                 ServerId = serverId,
                 Language = normalized,
+                LaunchInstanceId = launchInstanceId,
                 Created = DateTime.UtcNow
             };
             _tickets[ticket.Value] = ticket;

--- a/Jondo.Unity.Tests/Network/ClientLaunchCleanupTests.cs
+++ b/Jondo.Unity.Tests/Network/ClientLaunchCleanupTests.cs
@@ -1,0 +1,130 @@
+using System.Threading;
+using Jondo.Unity.Server.Network;
+using Xunit;
+
+namespace Jondo.Unity.Tests.Network
+{
+    [CollectionDefinition(Name, DisableParallelization = true)]
+    public sealed class ClientLaunchRegistryCollection
+    {
+        public const string Name = "Client launch registry";
+    }
+
+    [Collection(ClientLaunchRegistryCollection.Name)]
+    public class ClientLaunchCleanupTests
+    {
+        private static long _nextAccountId = 9_000_000_000;
+
+        [Fact]
+        public void Disconnect_releases_the_launch_owned_by_that_game_socket()
+        {
+            long accountId = Interlocked.Increment(ref _nextAccountId);
+            var launch = ClientLaunchRegistry.Register(
+                accountId, "token", Guid.NewGuid().ToString("N"), "fr");
+            var session = BoundSession(accountId, launch.InstanceId);
+
+            try
+            {
+                Assert.True(SessionRegistry.Register(session));
+                Assert.True(ClientLaunchRegistry.IsActive(accountId));
+
+                Assert.True(SessionRegistry.Unregister(session));
+
+                Assert.False(ClientLaunchRegistry.IsActive(accountId));
+            }
+            finally
+            {
+                SessionRegistry.Unregister(session);
+                ClientLaunchRegistry.RemoveByAccount(accountId);
+            }
+        }
+
+        [Fact]
+        public void Late_disconnect_cannot_release_a_newer_launch_of_the_same_account()
+        {
+            long accountId = Interlocked.Increment(ref _nextAccountId);
+            var oldLaunch = ClientLaunchRegistry.Register(
+                accountId, "old-token", Guid.NewGuid().ToString("N"), "fr");
+            var oldSession = BoundSession(accountId, oldLaunch.InstanceId);
+
+            try
+            {
+                Assert.True(SessionRegistry.Register(oldSession));
+                ClientLaunchRegistry.RemoveByAccount(accountId);
+                var newLaunch = ClientLaunchRegistry.Register(
+                    accountId, "new-token", Guid.NewGuid().ToString("N"), "fr");
+
+                Assert.True(SessionRegistry.Unregister(oldSession));
+
+                Assert.True(ClientLaunchRegistry.TryGetByAccount(accountId, out var active));
+                Assert.Equal(newLaunch.InstanceId, active?.InstanceId);
+            }
+            finally
+            {
+                SessionRegistry.Unregister(oldSession);
+                ClientLaunchRegistry.RemoveByAccount(accountId);
+            }
+        }
+
+        [Fact]
+        public void Zaap_handshake_without_a_bound_game_socket_expires()
+        {
+            long accountId = Interlocked.Increment(ref _nextAccountId);
+            string hash = Guid.NewGuid().ToString("N");
+            var launch = ClientLaunchRegistry.Register(accountId, "token", hash, "fr");
+
+            try
+            {
+                Assert.True(ClientLaunchRegistry.TryConnect(
+                    launch.InstanceId, hash, out string gameSession));
+                Assert.True(ClientLaunchRegistry.TryGetByGameSession(gameSession, out _));
+
+                Assert.Equal(1, ClientLaunchRegistry.SoltarLosCaducados(TimeSpan.Zero));
+
+                Assert.False(ClientLaunchRegistry.IsActive(accountId));
+                Assert.False(ClientLaunchRegistry.TryGetByGameSession(gameSession, out _));
+            }
+            finally
+            {
+                ClientLaunchRegistry.RemoveByAccount(accountId);
+            }
+        }
+
+        [Fact]
+        public void Bound_game_socket_prevents_launch_expiration()
+        {
+            long accountId = Interlocked.Increment(ref _nextAccountId);
+            var launch = ClientLaunchRegistry.Register(
+                accountId, "token", Guid.NewGuid().ToString("N"), "fr");
+            var session = BoundSession(accountId, launch.InstanceId);
+
+            try
+            {
+                Assert.True(SessionRegistry.Register(session));
+
+                Assert.Equal(0, ClientLaunchRegistry.SoltarLosCaducados(TimeSpan.Zero));
+                Assert.True(ClientLaunchRegistry.IsActive(accountId));
+            }
+            finally
+            {
+                SessionRegistry.Unregister(session);
+                ClientLaunchRegistry.RemoveByAccount(accountId);
+            }
+        }
+
+        private static GameSession BoundSession(long accountId, int launchInstanceId)
+        {
+            var ticket = SessionRegistry.Issue(
+                accountId, serverId: 1, language: "fr",
+                launchInstanceId: launchInstanceId);
+            var redeemed = SessionRegistry.Redeem(ticket.Value);
+            Assert.NotNull(redeemed);
+
+            var session = GameSession.SinSocket();
+            session.BindAccount(
+                redeemed.AccountId, redeemed.ServerId, redeemed.Language,
+                redeemed.LaunchInstanceId);
+            return session;
+        }
+    }
+}


### PR DESCRIPTION
## Resumen
- vincula cada ticket y socket de juego con la instancia de lanzamiento que los creó
- libera inmediatamente el lanzamiento cuando se cierra su socket de juego
- impide que el cierre tardío de un socket antiguo borre un lanzamiento nuevo
- deja caducar los handshakes de Zaap que nunca llegan a presentar un ticket, sin tocar clientes realmente conectados

## Incidente reproducido
El lanzamiento 15 completó el handshake de Zaap y abrió una segunda conexión TCP, pero nunca llegó a `Socket bound to session`. El registro antiguo interpretaba la sola `gameSession` de Zaap como un cliente vivo y dejaba la cuenta ocupada indefinidamente.

## Pruebas
- `ClientLaunchCleanupTests`: 4/4
- suite completa: 503/503
- validación en VPS: cierre de la sesión, liberación registrada y relanzamiento de la misma cuenta sin «cliente ya activo»

No se incluye ningún binario en esta PR.