### PR TITLE
Completar el abandono de combate tras el acuse de muerte

### DIFF
--- a/Jondo.Unity.Protocol/Op.cs
+++ b/Jondo.Unity.Protocol/Op.cs
@@ -10,7 +10,7 @@
 namespace Jondo.Unity.Protocol;
 
 /// <summary>
-/// Los 253 opcodes que el emulador usa de verdad, con nombre.
+/// Los 254 opcodes que el emulador usa de verdad, con nombre.
 ///
 /// Son <c>const</c> y no propiedades a propósito: hay etiquetas de <c>switch</c> por medio, y
 /// una etiqueta de <c>case</c> exige una constante de tiempo de compilación.
@@ -799,6 +799,13 @@ public static class Op
 
     /// <summary>Cierra el dialogo; el cliente no cierra la ventana del zaap por si mismo. f1 es un motivo fijo, no algo que calcular.</summary>
     public const string Kld = "kld";
+
+    /// <summary>
+    /// The player abandons an ongoing fight. Measured in sacro-rendirse.pcapng and the two other
+    /// surrender captures: the server answers with a death sequence and waits for jti before the
+    /// result screen.
+    /// </summary>
+    public const string Kme = "kme";
 
     /// <summary>Parte de la rafaga final de 3.6.4.3 que dispara ibt (icg se envia tres veces). No aparece en ninguna de las 242 capturas.</summary>
     public const string Klp = "klp";

--- a/Jondo.Unity.Server/Handlers/FightHandler.cs
+++ b/Jondo.Unity.Server/Handlers/FightHandler.cs
@@ -1228,6 +1228,10 @@ namespace Jondo.Unity.Server.Handlers
                 // la pantalla de fin de combate cuando el último golpe la dejó esperando.
                 await AcuseAsync(stream, payload);
             }
+            else if (payloadStr.Contains(Op.Uri(Op.Kme)))
+            {
+                await AbandonAsync(stream);
+            }
             else if (payloadStr.Contains(Op.Uri(Op.Hoy)))
             {
                 await HandleFightOptionToggleRequest(stream, payload);
@@ -3750,6 +3754,62 @@ namespace Jondo.Unity.Server.Handlers
             await EndFightAsync(stream, fight);
         }
 
+        /// <summary>
+        /// Abandonment follows the measured death handshake from sacro-rendirse.pcapng: the
+        /// fighter dies inside an action sequence, and the result screen waits for the matching
+        /// jti acknowledgement. Sending kuf/jyg immediately can cut through an unfinished cast.
+        /// </summary>
+        public static async Task AbandonAsync(NetworkStream stream)
+        {
+            var fight = GetCurrentFight();
+            if (fight == null)
+            {
+                Program.LogDebug("[Fight] Ignored kme because the session has no active fight.");
+                return;
+            }
+            if (fight.State != FightState.Ongoing)
+            {
+                Program.LogDebug($"[Fight] Ignored kme for fight #{fight.FightId} in state " +
+                                 $"{fight.State}; no placement surrender was captured.");
+                return;
+            }
+
+            var quitter = AbandoningFighter(fight, GameState.CharacterId);
+            if (quitter == null)
+            {
+                Program.LogDebug($"[Fight] Ignored kme because character {GameState.CharacterId} " +
+                                 $"is not an alive fighter in fight #{fight.FightId}.");
+                return;
+            }
+
+            if (fight.CurrentFighter == quitter) PararElReloj(fight);
+
+            await WriteFrameAsync(stream, ConnectionProtocol.Push(Op.Jto,
+                Network.FightProtocol.BuildSequenceStart(quitter.Id,
+                                                         Network.FightProtocol.ActionSequence)));
+
+            quitter.CurrentHP = 0;
+            await WriteFrameAsync(stream, ConnectionProtocol.Push(Op.Jwe,
+                Network.FightProtocol.BuildDeath(quitter.Id, quitter.Id)));
+            await CaenSusInvocadosAsync(stream, fight, quitter);
+            await ReenviarLaListaAsync(stream, fight);
+
+            int closure = fight.SiguienteAccion();
+            await WriteFrameAsync(stream, ConnectionProtocol.Push(Op.Jwi,
+                Network.FightProtocol.BuildSequenceEnd(closure, quitter.Id,
+                                                       Network.FightProtocol.ActionSequence)));
+
+            Program.LogDebug($"[Fight] Character {quitter.Id} abandoned fight #{fight.FightId}; " +
+                             $"waiting for jti action {closure} before the result screen.");
+            await CheckFightOverAsync(stream, fight, closure);
+        }
+
+        internal static Fighter? AbandoningFighter(FightInstance? fight, long characterId)
+        {
+            if (fight == null || fight.State != FightState.Ongoing) return null;
+            return fight.Team0.FirstOrDefault(fighter => fighter.Id == characterId && fighter.IsAlive);
+        }
+
         private static async Task<bool> CheckFightOverAsync(NetworkStream stream, FightInstance fight,
                                                             int esperarAcuse = 0)
         {
@@ -3759,15 +3819,21 @@ namespace Jondo.Unity.Server.Handlers
 
             // Si el golpe que lo ha terminado acaba de salir, no se le enseña el final hasta que el
             // cliente diga que ha tragado la secuencia; si no, se come las animaciones.
-            if (esperarAcuse != 0)
+            if (DeferFightEndUntilAck(fight, esperarAcuse))
             {
-                fight.FinPendiente = esperarAcuse;
                 Program.LogDebug($"[Combate] Se acabó, pero se espera a que el cliente acuse la " +
                                  $"acción {esperarAcuse} antes de enseñar el final.");
                 return true;
             }
 
             await EndFightAsync(stream, fight);
+            return true;
+        }
+
+        internal static bool DeferFightEndUntilAck(FightInstance fight, int actionId)
+        {
+            if (actionId == 0) return false;
+            fight.FinPendiente = actionId;
             return true;
         }
 

--- a/Jondo.Unity.Server/Network/GameNodeProxy.cs
+++ b/Jondo.Unity.Server/Network/GameNodeProxy.cs
@@ -863,6 +863,7 @@ namespace Jondo.Unity.Server.Network
                          || payloadStr.Contains(Op.Uri(Op.Jwh))
                          || payloadStr.Contains(Op.Uri(Op.Jwn))
                          || payloadStr.Contains(Op.Uri(Op.Jti))
+                         || payloadStr.Contains(Op.Uri(Op.Kme))
                          || payloadStr.Contains(Op.Uri(Op.Hoy))
                          || payloadStr.Contains(Op.Uri(Op.Kwr)) || payloadStr.Contains(Op.Uri(Op.Kwj))
                          || payloadStr.Contains(Op.Uri(Op.Kwv)) || payloadStr.Contains(Op.Uri(Op.Kwi))

--- a/Jondo.Unity.Tests/Combat/FightAbandonmentTests.cs
+++ b/Jondo.Unity.Tests/Combat/FightAbandonmentTests.cs
@@ -1,0 +1,59 @@
+using Jondo.Unity.Server.Handlers;
+using Jondo.Unity.World.Fights;
+using Xunit;
+
+namespace Jondo.Unity.Tests.Combat
+{
+    public class FightAbandonmentTests
+    {
+        [Fact]
+        public void Placement_fights_cannot_enter_the_surrender_death_path()
+        {
+            var (fight, player) = FightWithPlayer();
+
+            Assert.Equal(FightState.Placement, fight.State);
+            Assert.Null(FightHandler.AbandoningFighter(fight, player.Id));
+            Assert.Equal(100, player.CurrentHP);
+        }
+
+        [Fact]
+        public void Only_the_alive_session_character_can_abandon_an_ongoing_fight()
+        {
+            var (fight, player) = FightWithPlayer();
+            fight.StartFight();
+
+            Assert.Same(player, FightHandler.AbandoningFighter(fight, player.Id));
+            Assert.Null(FightHandler.AbandoningFighter(fight, player.Id + 1));
+
+            player.CurrentHP = 0;
+            Assert.Null(FightHandler.AbandoningFighter(fight, player.Id));
+        }
+
+        [Fact]
+        public void Surrender_results_stay_pending_until_the_death_sequence_is_acknowledged()
+        {
+            var (fight, player) = FightWithPlayer();
+            fight.StartFight();
+            player.CurrentHP = 0;
+
+            Assert.True(FightHandler.DeferFightEndUntilAck(fight, 42));
+            Assert.Equal(42, fight.FinPendiente);
+        }
+
+        private static (FightInstance Fight, Fighter Player) FightWithPlayer()
+        {
+            var fight = new FightInstance(1, 1);
+            var player = new Fighter { Id = 10, MaxHP = 100, CurrentHP = 100 };
+            var monster = new Fighter
+            {
+                Id = -1,
+                IsMonster = true,
+                MaxHP = 100,
+                CurrentHP = 100,
+            };
+            fight.AddPlayer(player);
+            fight.AddMonster(monster);
+            return (fight, player);
+        }
+    }
+}


### PR DESCRIPTION
## Resumen
- enruta `kme` al combate activo y sólo permite abandonar al personaje vivo de la sesión
- reproduce la secuencia de muerte medida: inicio de acción, muerte, caída de invocaciones, actualización del carrusel y fin de acción
- espera el acuse `jti` antes de mostrar el resultado para no cortar una secuencia pendiente
- ignora el abandono durante la colocación, donde no existe una secuencia medida

## Fuente de protocolo
La forma está documentada a partir de `sacro-rendirse.pcapng` y las otras dos capturas de rendición del repositorio.

## Pruebas
- `FightAbandonmentTests`: 3/3
- suite completa: 502/502
- validación manual en el cliente: el botón de abandono termina correctamente el combate