### PR TITLE
Implementar las curas fijas y diferidas

### DIFF
--- a/Jondo.Unity.Server/Handlers/FightHandler.cs
+++ b/Jondo.Unity.Server/Handlers/FightHandler.cs
@@ -776,6 +776,7 @@ namespace Jondo.Unity.Server.Handlers
             Poner(27, sabiduria / PorCadaDiez);   // esquiva de puntos de acción
             Poner(28, sabiduria / PorCadaDiez);   // esquiva de puntos de movimiento
             Poner(12, GameState.StatWisdom);      // sabiduría
+            Poner(49, 0);                         // flat heals
             Poner(26, 0);                         // invocaciones
             Poner(50, 0);                         // reenvío
             Poner(75, 0);                         // erosión
@@ -1729,6 +1730,10 @@ namespace Jondo.Unity.Server.Handlers
                 await ReenviarLaListaAsync(stream, fight);
             }
 
+            // Delayed one-shot heals become due at the start of their global round, before the
+            // ordinary expiry sweep can remove their temporary panel entry.
+            await ApplyDelayedHealingAsync(stream, fight);
+
             // Se caen los embrujos cumplidos antes de devolver los puntos, para que lo que se
             // devuelva sea lo que de verdad toca esta ronda. Y de cada uno hay que avisar con su
             // jya, que es como el cliente los quita del panel: por su número, uno a uno.
@@ -1866,6 +1871,49 @@ namespace Jondo.Unity.Server.Handlers
                 // mismo que usan los monstruos.
                 await PassTurnAsync(stream);
             }
+        }
+
+        /// <summary>
+        /// Announces delayed heals activated by the effect engine and removes their temporary buff
+        /// entry from the client. The engine has already capped and applied HP before this method
+        /// writes any packet.
+        /// </summary>
+        private static async Task ApplyDelayedHealingAsync(NetworkStream stream, FightInstance fight)
+        {
+            var due = Managers.EffectEngine.ActivateDelayedHealing(fight, fight.RoundNumber);
+            if (due.Count == 0) return;
+
+            long sequenceOwner = fight.CurrentFighter?.Id ?? 0;
+            await WriteFrameAsync(stream, ConnectionProtocol.Push(Op.Jto,
+                Network.FightProtocol.BuildSequenceStart(
+                    sequenceOwner, Network.FightProtocol.ActionSequence)));
+
+            foreach (var result in due)
+            {
+                var caster = fight.Team0.Find(f => f.Id == result.CasterId)
+                          ?? fight.Team1.Find(f => f.Id == result.CasterId);
+                long sourceId = caster?.Id ?? result.CasterId;
+
+                if (result.Healed > 0)
+                {
+                    await WriteFrameAsync(stream, ConnectionProtocol.Push(Op.Jwe,
+                        Network.FightProtocol.BuildHeal(sourceId, result.Healed, result.Target.Id)));
+                    if (caster != null)
+                    {
+                        await ChallengeWatcher.HealedAsync(stream, fight, caster, result.Target);
+                    }
+                    await RefrescarLaVidaAsync(stream, fight, result.Target);
+                }
+
+                await WriteFrameAsync(stream, ConnectionProtocol.Push(Op.Jya,
+                    Network.FightProtocol.BuildBuffGone(result.Target.Id, result.Buff.Numero)));
+                Program.LogDebug($"[Fight] Delayed heal from {sourceId} to {result.Target.Id}: " +
+                                 $"{result.Healed} HP at round {fight.RoundNumber}.");
+            }
+
+            await WriteFrameAsync(stream, ConnectionProtocol.Push(Op.Jwi,
+                Network.FightProtocol.BuildSequenceEnd(
+                    fight.SiguienteAccion(), sequenceOwner, Network.FightProtocol.ActionSequence)));
         }
 
         /// <summary>

--- a/Jondo.Unity.Server/Managers/EffectEngine.cs
+++ b/Jondo.Unity.Server/Managers/EffectEngine.cs
@@ -72,6 +72,15 @@ namespace Jondo.Unity.Server.Managers
         public int CollisionDamageToBlocker { get; init; }
     }
 
+    /// <summary>A delayed one-shot heal that has just reached its activation round.</summary>
+    internal sealed class DelayedHealOutcome
+    {
+        public Fighter Target { get; init; } = null!;
+        public long CasterId { get; init; }
+        public Buff Buff { get; init; } = null!;
+        public int Healed { get; init; }
+    }
+
     /// <summary>
     /// El motor de efectos: coge las entradas del EffectsJson de un hechizo y las convierte en
     /// cosas que le pasan a alguien.
@@ -248,6 +257,33 @@ namespace Jondo.Unity.Server.Managers
 
         public static bool VaAlSuelo(int efecto) => AlSuelo.Contains(efecto);
 
+        /// <summary>Fixed healing. Intelligence scales the roll and characteristic 49 is flat.</summary>
+        private const int FixedHeal = EffectSupport.Heal;
+
+        private const int IntelligenceCharacteristic = 15;
+        private const int HealsCharacteristic = 49;
+
+        /// <summary>Effect 1159, received healing as a percentage multiplier.</summary>
+        private const int ReceivedHealingPercent = 1159;
+
+        /// <summary>
+        /// Applies the fixed-heal formula after the shared effect roll and zone falloff.
+        /// Power and damage bonuses do not participate; flat heals are added after Intelligence,
+        /// and received-healing multipliers are applied last.
+        /// </summary>
+        internal static int CalculateFixedHeal(int baseHeal, int intelligence, int flatHeals,
+                                               int receivedMultiplier = 100)
+        {
+            if (baseHeal <= 0 || receivedMultiplier <= 0) return 0;
+
+            long scaled = (long)baseHeal * Math.Max(0L, 100L + intelligence) / 100L + flatHeals;
+            if (scaled <= 0) return 0;
+
+            double received = scaled * (receivedMultiplier / 100.0);
+            if (received >= int.MaxValue) return int.MaxValue;
+            return Math.Max(0, (int)Math.Round(received));
+        }
+
         /// <summary>"Cura: #1% de los PdV máximos". El dado es el porcentaje.</summary>
         private const int CuraPorcentual = EffectSupport.HealPercent;
 
@@ -314,25 +350,46 @@ namespace Jondo.Unity.Server.Managers
                                                   string disparador, int ronda, int hondo = 0,
                                                   int celdaApuntada = -1, bool critico = false)
         {
-            var fuera = new List<Outcome>();
-            if (hondo > HondoMaximo) return fuera;
+            if (hondo > HondoMaximo) return new List<Outcome>();
+            return ResolveEffects(combate, quienLanza, hechizo, grado, objetivo, disparador, ronda,
+                                  EfectosDeLaTirada(hechizo, grado, critico), hondo,
+                                  celdaApuntada);
+        }
 
-            var lista = EfectosDeLaTirada(hechizo, grado, critico);
+        /// <summary>
+        /// Runs the real effect pipeline over an explicit list. Tests inject catalogue-shaped
+        /// effects here so they exercise targeting, shared rolls, delays and HP mutation without
+        /// replacing the production database.
+        /// </summary>
+        internal static List<Outcome> ResolveEffects(
+            FightInstance combat, Fighter caster, int spell, int grade, Fighter target,
+            string trigger, int round, IReadOnlyList<SpellEffect> effects, int depth = 0,
+            int aimedCell = -1, Func<SpellEffect, int> rollEffect = null)
+        {
+            var fuera = new List<Outcome>();
+            if (depth > HondoMaximo) return fuera;
 
             // Los efectos que van a suertes: se sortean ANTES de recorrer nada, y los que no salen
             // se quedan fuera de esta resolución.
-            var descartados = Sortear(lista);
+            var descartados = Sortear(effects);
 
-            foreach (var efecto in lista)
+            foreach (var efecto in effects)
             {
                 if (descartados.Contains(efecto)) continue;
 
                 bool leToca = false;
                 foreach (var d in efecto.Disparadores())
                 {
-                    if (string.Equals(d, disparador, StringComparison.OrdinalIgnoreCase)) { leToca = true; break; }
+                    if (string.Equals(d, trigger, StringComparison.OrdinalIgnoreCase)) { leToca = true; break; }
                 }
                 if (!leToca) continue;
+
+                // Fixed healing follows damage's roll semantics: one effect roll is shared by all
+                // recipients in the zone, then each recipient gets its own distance falloff.
+                int sharedHealRoll = efecto.EffectId == FixedHeal
+                    ? (rollEffect != null ? rollEffect(efecto)
+                                          : DelDado(efecto.DiceNum, efecto.DiceSide, efecto.Value))
+                    : int.MinValue;
 
                 // Lo que se pone EN EL SUELO no busca a nadie: va a la casilla, esté quien esté.
                 //
@@ -343,8 +400,8 @@ namespace Jondo.Unity.Server.Managers
                 // la lista estaban bien; lo que no llegaba era la orden.
                 if (VaAlSuelo(efecto.EffectId))
                 {
-                    var puesta = Aplicar(combate, quienLanza, quienLanza, hechizo, grado, efecto,
-                                         ronda, celdaApuntada);
+                    var puesta = Aplicar(combat, caster, caster, spell, grade, efecto,
+                                         round, aimedCell, sharedHealRoll);
                     if (puesta != null) fuera.Add(puesta);
                     continue;
                 }
@@ -355,10 +412,10 @@ namespace Jondo.Unity.Server.Managers
                 // alcanzara a tres bichos movería al lanzador tres veces.
                 bool unaSolaVez = efecto.EffectId == Retroceder || efecto.EffectId == Avanzar;
 
-                foreach (var sobre in AQuien(combate, quienLanza, objetivo, efecto, celdaApuntada))
+                foreach (var sobre in AQuien(combat, caster, target, efecto, aimedCell))
                 {
-                    var hecho = Aplicar(combate, quienLanza, sobre, hechizo, grado, efecto, ronda,
-                                        celdaApuntada);
+                    var hecho = Aplicar(combat, caster, sobre, spell, grade, efecto, round,
+                                        aimedCell, sharedHealRoll);
                     if (unaSolaVez)
                     {
                         if (hecho != null) fuera.Add(hecho);
@@ -370,9 +427,9 @@ namespace Jondo.Unity.Server.Managers
                     // Un efecto puede encadenar otro hechizo: es como se enganchan las actitudes.
                     if (hecho.HechizoEncadenado != 0)
                     {
-                        fuera.AddRange(Resolver(combate, quienLanza, hecho.HechizoEncadenado,
-                                                hecho.GradoEncadenado, sobre, AlLanzar, ronda,
-                                                hondo + 1, celdaApuntada));
+                        fuera.AddRange(Resolver(combat, caster, hecho.HechizoEncadenado,
+                                                hecho.GradoEncadenado, sobre, AlLanzar, round,
+                                                depth + 1, aimedCell));
                     }
                 }
             }
@@ -529,7 +586,8 @@ namespace Jondo.Unity.Server.Managers
 
         private static Outcome Aplicar(FightInstance combate, Fighter quienLanza, Fighter sobre,
                                             int hechizo, int grado, SpellEffect efecto, int ronda,
-                                            int celdaApuntada = -1)
+                                            int celdaApuntada = -1,
+                                            int sharedHealRoll = int.MinValue)
         {
             // El daño lo lleva quien ya lo llevaba; aquí no se toca.
             if (efecto.EffectId >= DanoPrimero && efecto.EffectId <= DanoUltimo) return null;
@@ -783,25 +841,46 @@ namespace Jondo.Unity.Server.Managers
                 };
             }
 
+            // Fixed healing uses one roll for the whole zone. Distance falloff changes only that
+            // shared base; Intelligence, flat heals and the target's received-healing multiplier
+            // are then applied independently. Power and damage bonuses never participate.
+            if (efecto.EffectId == FixedHeal)
+            {
+                if (sobre == null || !sobre.IsAlive) return null;
+
+                int baseHeal = sharedHealRoll != int.MinValue
+                    ? sharedHealRoll
+                    : DelDado(efecto.DiceNum, efecto.DiceSide, efecto.Value);
+                if (baseHeal <= 0) return null;
+
+                int distance = celdaApuntada >= 0
+                    ? Jondo.Unity.World.Maps.MapGeometry.Distance(celdaApuntada, sobre.CellId)
+                    : 0;
+                baseHeal = ConLaCaidaDeLaZona(baseHeal, efecto, distance);
+
+                int intelligence = quienLanza.Intelligence
+                    + quienLanza.Buffs.De(IntelligenceCharacteristic, ronda);
+                int flatHeals = quienLanza.Otra(HealsCharacteristic)
+                    + quienLanza.Buffs.De(HealsCharacteristic, ronda);
+                int receivedMultiplier = sobre.Buffs.Multiplicador(ReceivedHealingPercent, ronda);
+                int points = CalculateFixedHeal(baseHeal, intelligence, flatHeals,
+                                                receivedMultiplier);
+                return ApplyHealing(combate, quienLanza, sobre, hechizo, grado, efecto,
+                                    ronda, points);
+            }
+
             // Las curaciones por tanto por ciento de la vida máxima. El dado es el PORCENTAJE, no
             // los puntos: la Baliza de Supervivencia cura un siete por ciento del tope de quien
             // recibe, y en el cable eso viaja ya resuelto en puntos.
             if (efecto.EffectId == CuraPorcentual)
             {
+                if (sobre == null || !sobre.IsAlive) return null;
                 int cuanto = efecto.DiceNum != 0 ? efecto.DiceNum : efecto.Value;
                 if (cuanto <= 0) return null;
 
                 int puntos = Math.Max(1, sobre.MaxHP * cuanto / 100);
-                puntos = Math.Min(puntos, Math.Max(0, sobre.MaxHP - sobre.CurrentHP));
-                if (puntos <= 0) return null;
-
-                sobre.CurrentHP += puntos;
-                return new Outcome
-                {
-                    Sobre = sobre, Efecto = efecto,
-                    HechizoOrigen = hechizo, NivelOrigen = grado,
-                    Cura = puntos,
-                };
+                return ApplyHealing(combate, quienLanza, sobre, hechizo, grado, efecto,
+                                    ronda, puntos);
             }
 
             // Los que MULTIPLICAN: "daños sufridos x110%", "curas recibidas x50%". No tocan
@@ -896,6 +975,90 @@ namespace Jondo.Unity.Server.Managers
         }
 
         /// <summary>
+        /// Applies an immediate heal or records it as a one-shot buff when the catalogue carries a
+        /// delay. A delayed heal is scheduled even while the target is full because it may be hurt
+        /// before the activation round; missing-life capping therefore happens only on activation.
+        /// </summary>
+        private static Outcome ApplyHealing(FightInstance combat, Fighter caster, Fighter target,
+                                            int spell, int grade, SpellEffect effect, int round,
+                                            int points)
+        {
+            if (target == null || !target.IsAlive || points <= 0) return null;
+
+            if (effect.Delay > 0)
+            {
+                var pending = target.Buffs.Poner(new Buff
+                {
+                    EffectId = effect.EffectId,
+                    EffectUid = effect.EffectUid,
+                    Cuanto = points,
+                    PendingHealPoints = points,
+                    HechizoOrigen = spell,
+                    NivelOrigen = grade,
+                    Quien = caster.Id,
+                    Disparador = AlLanzar,
+                    CaducaEnRonda = Caduca(effect, round),
+                    EmpiezaEnRonda = Empieza(effect, round),
+                    Apila = SeApila(effect),
+                }, combat.SiguienteEmbrujo);
+
+                return new Outcome
+                {
+                    Sobre = target,
+                    Efecto = effect,
+                    Buff = pending,
+                    HechizoOrigen = spell,
+                    NivelOrigen = grade,
+                };
+            }
+
+            int applied = Math.Min(points, Math.Max(0, target.MaxHP - target.CurrentHP));
+            if (applied <= 0) return null;
+
+            target.CurrentHP += applied;
+            return new Outcome
+            {
+                Sobre = target,
+                Efecto = effect,
+                HechizoOrigen = spell,
+                NivelOrigen = grade,
+                Cura = applied,
+            };
+        }
+
+        /// <summary>
+        /// Activates every delayed one-shot heal due in this combat. Dead targets are deliberately
+        /// skipped: ordinary healing is not a resurrection path. The pending buff is consumed in
+        /// either case so it cannot fire again on the next fighter's turn in the same round.
+        /// </summary>
+        internal static List<DelayedHealOutcome> ActivateDelayedHealing(FightInstance combat, int round)
+        {
+            var results = new List<DelayedHealOutcome>();
+            foreach (var target in Todos(combat))
+            {
+                foreach (var pending in target.Buffs.TakeDueHealing(round))
+                {
+                    int healed = 0;
+                    if (target.IsAlive)
+                    {
+                        healed = Math.Min(pending.PendingHealPoints,
+                                          Math.Max(0, target.MaxHP - target.CurrentHP));
+                        target.CurrentHP += healed;
+                    }
+
+                    results.Add(new DelayedHealOutcome
+                    {
+                        Target = target,
+                        CasterId = pending.Quien,
+                        Buff = pending,
+                        Healed = healed,
+                    });
+                }
+            }
+            return results;
+        }
+
+        /// <summary>
         /// La lista de efectos que toca, según haya salido crítico o no.
         ///
         /// Un hechizo trae DOS listas en la base y la crítica no es "la normal multiplicada": es
@@ -984,7 +1147,10 @@ namespace Jondo.Unity.Server.Managers
         private static int DelDado(int minimo, int maximo, int valor)
         {
             if (minimo == 0 && maximo == 0) return valor;
-            if (maximo > minimo) return _azar.Next(minimo, maximo + 1);
+            if (maximo > minimo)
+            {
+                lock (_azar) return _azar.Next(minimo, maximo + 1);
+            }
             return minimo != 0 ? minimo : valor;
         }
 

--- a/Jondo.Unity.Tests/Combat/EffectSupportTests.cs
+++ b/Jondo.Unity.Tests/Combat/EffectSupportTests.cs
@@ -12,22 +12,22 @@ namespace Jondo.Unity.Tests.Combat
     /// <see cref="EffectSupport"/>, so an effect gaining an implementation without being added here
     /// would not compile.
     ///
-    /// Measured over the 872 effects in <c>world.db</c>: 20 have code, 205 are applied as a
-    /// characteristic, and <b>647 do nothing at all</b> — and 15,841 of the 34,823 spell levels
-    /// carry at least one of those 647.
+    /// Measured over the 872 effects in <c>world.db</c>: 21 have code, 205 are applied as a
+    /// characteristic, and <b>646 do nothing at all</b> — and 15,348 of the 34,823 spell levels
+    /// carry at least one of those 646.
     /// </remarks>
     public class EffectSupportTests
     {
         /// <summary>
-        /// Effect 108 is healing, and it does nothing. The card says it heals, the animation plays,
-        /// and nobody's life goes up. It is on 751 spell levels.
+        /// Effect 108 has no characteristic and belongs to category 2, but direct support wins over
+        /// both catalogue fields. It occurs on 751 spell levels.
         /// </summary>
         [Fact]
-        public void Healing_is_still_not_implemented_and_says_so()
+        public void Fixed_healing_is_implemented_despite_its_catalogue_row()
         {
-            // Its catalogue row carries no characteristic, which is exactly why it falls through.
-            Assert.Equal(EffectSupportKind.PanelOnly, EffectSupport.Classify(108, 0, 2));
-            Assert.DoesNotContain(108, EffectSupport.HandledDirectly);
+            Assert.Equal(EffectSupportKind.Direct,
+                         EffectSupport.Classify(EffectSupport.Heal, 0, 2));
+            Assert.Contains(EffectSupport.Heal, EffectSupport.HandledDirectly);
         }
 
         [Theory]
@@ -39,6 +39,7 @@ namespace Jondo.Unity.Tests.Combat
         [InlineData(EffectSupport.RemoveState)]
         [InlineData(EffectSupport.CastSpell)]
         [InlineData(EffectSupport.Summon)]
+        [InlineData(EffectSupport.Heal)]
         [InlineData(EffectSupport.HealPercent)]
         [InlineData(EffectSupport.Kill)]
         public void The_effects_with_code_are_reported_as_such(int effectId)

--- a/Jondo.Unity.Tests/Combat/HealingTests.cs
+++ b/Jondo.Unity.Tests/Combat/HealingTests.cs
@@ -1,0 +1,232 @@
+using Jondo.Unity.Server.Managers;
+using Jondo.Unity.World.Combat;
+using Jondo.Unity.World.Fights;
+using Jondo.Unity.World.Maps;
+using Xunit;
+
+namespace Jondo.Unity.Tests.Combat
+{
+    public class HealingTests
+    {
+        [Fact]
+        public void One_fixed_heal_roll_is_shared_across_the_zone_before_distance_falloff()
+        {
+            const int center = 200;
+            int edge = MapGeometry.GetNeighbors(center).First();
+            var fight = new FightInstance(1, 1);
+            var caster = Fighter(1, 150, 1000, 1000);
+            caster.Intelligence = 100;
+            caster.Otras[49] = 5;
+            var centerTarget = Fighter(2, center, 100, 1000);
+            var edgeTarget = Fighter(3, edge, 100, 1000);
+            fight.AddPlayer(caster);
+            fight.AddPlayer(centerTarget);
+            fight.AddPlayer(edgeTarget);
+
+            var effect = FixedHeal(diceMin: 10, diceMax: 90, targetMask: "a");
+            effect = new SpellEffect
+            {
+                EffectId = effect.EffectId,
+                EffectUid = effect.EffectUid,
+                DiceNum = effect.DiceNum,
+                DiceSide = effect.DiceSide,
+                Triggers = effect.Triggers,
+                TargetMask = effect.TargetMask,
+                Forma = 'C',
+                Tamano = 2,
+                PasoDeCaida = 10,
+                TopeDeCaida = 4,
+            };
+            int rolls = 0;
+
+            var outcomes = EffectEngine.ResolveEffects(
+                fight, caster, 100, 1, centerTarget, EffectEngine.AlLanzar, 1,
+                new[] { effect }, aimedCell: center,
+                rollEffect: _ =>
+                {
+                    rolls++;
+                    return 40;
+                });
+
+            Assert.Equal(1, rolls);
+            Assert.Equal(85, outcomes.Single(o => o.Sobre == centerTarget).Cura);
+            Assert.Equal(77, outcomes.Single(o => o.Sobre == edgeTarget).Cura);
+            Assert.Equal(185, centerTarget.CurrentHP);
+            Assert.Equal(177, edgeTarget.CurrentHP);
+        }
+
+        [Fact]
+        public void Immediate_healing_is_capped_by_missing_life()
+        {
+            var fight = new FightInstance(1, 1);
+            var caster = Fighter(1, 100, 1000, 1000);
+            var target = Fighter(2, 101, 975, 1000);
+            fight.AddPlayer(caster);
+            fight.AddPlayer(target);
+
+            var outcomes = EffectEngine.ResolveEffects(
+                fight, caster, 100, 1, target, EffectEngine.AlLanzar, 1,
+                new[] { FixedHeal(100, 100) });
+
+            Assert.Equal(25, Assert.Single(outcomes).Cura);
+            Assert.Equal(1000, target.CurrentHP);
+        }
+
+        [Fact]
+        public void Fixed_healing_reads_combat_bonuses_and_received_healing()
+        {
+            var fight = new FightInstance(1, 1);
+            var caster = Fighter(1, 100, 1000, 1000);
+            caster.Intelligence = 100;
+            caster.Power = 10_000;
+            caster.Otras[49] = 5;
+            caster.Buffs.Poner(new Buff
+            {
+                EffectId = 1,
+                EffectUid = 10,
+                Caracteristica = 15,
+                Cuanto = 50,
+                Quien = caster.Id,
+                EmpiezaEnRonda = 1,
+                CaducaEnRonda = -1,
+            }, fight.SiguienteEmbrujo);
+            caster.Buffs.Poner(new Buff
+            {
+                EffectId = 2,
+                EffectUid = 11,
+                Caracteristica = 49,
+                Cuanto = 2,
+                Quien = caster.Id,
+                EmpiezaEnRonda = 1,
+                CaducaEnRonda = -1,
+            }, fight.SiguienteEmbrujo);
+            var target = Fighter(2, 101, 500, 1000);
+            target.Buffs.Poner(new Buff
+            {
+                EffectId = 1159,
+                EffectUid = 12,
+                Cuanto = 50,
+                Quien = target.Id,
+                EmpiezaEnRonda = 1,
+                CaducaEnRonda = -1,
+            }, fight.SiguienteEmbrujo);
+            fight.AddPlayer(caster);
+            fight.AddPlayer(target);
+
+            var outcomes = EffectEngine.ResolveEffects(
+                fight, caster, 100, 1, target, EffectEngine.AlLanzar, 1,
+                new[] { FixedHeal(40, 40) });
+
+            Assert.Equal(54, Assert.Single(outcomes).Cura);
+            Assert.Equal(554, target.CurrentHP);
+        }
+
+        [Fact]
+        public void Percentage_healing_keeps_its_minimum_and_has_no_point_falloff()
+        {
+            const int center = 200;
+            int edge = MapGeometry.GetNeighbors(center).First();
+            var fight = new FightInstance(1, 1);
+            var caster = Fighter(1, 150, 1000, 1000);
+            var target = Fighter(2, edge, 500, 1000);
+            fight.AddPlayer(caster);
+            fight.AddPlayer(target);
+            var effect = new SpellEffect
+            {
+                EffectId = EffectSupport.HealPercent,
+                EffectUid = 2,
+                DiceNum = 5,
+                DiceSide = 10,
+                Triggers = EffectEngine.AlLanzar,
+                PasoDeCaida = 50,
+                TopeDeCaida = 4,
+            };
+
+            var outcomes = EffectEngine.ResolveEffects(
+                fight, caster, 100, 1, target, EffectEngine.AlLanzar, 1,
+                new[] { effect }, aimedCell: center,
+                rollEffect: _ => throw new InvalidOperationException(
+                    "Percentage healing must preserve its existing non-random behavior."));
+
+            Assert.Equal(50, Assert.Single(outcomes).Cura);
+            Assert.Equal(550, target.CurrentHP);
+        }
+
+        [Theory]
+        [InlineData(EffectSupport.Heal, 40, 40, 40)]
+        [InlineData(EffectSupport.HealPercent, 10, 20, 100)]
+        public void Delayed_healing_waits_then_activates_once(
+            int effectId, int diceMin, int diceMax, int expected)
+        {
+            var fight = new FightInstance(1, 1);
+            var caster = Fighter(1, 100, 1000, 1000);
+            var target = Fighter(2, 101, 1000, 1000);
+            fight.AddPlayer(caster);
+            fight.AddPlayer(target);
+            var effect = new SpellEffect
+            {
+                EffectId = effectId,
+                EffectUid = 3,
+                DiceNum = diceMin,
+                DiceSide = diceMax,
+                Delay = 2,
+                Triggers = EffectEngine.AlLanzar,
+            };
+
+            var scheduled = EffectEngine.ResolveEffects(
+                fight, caster, 100, 1, target, EffectEngine.AlLanzar, 1,
+                new[] { effect });
+
+            Assert.Equal(1000, target.CurrentHP);
+            Assert.NotNull(Assert.Single(scheduled).Buff);
+            target.CurrentHP = 900;
+            Assert.Empty(EffectEngine.ActivateDelayedHealing(fight, 2));
+
+            var activated = Assert.Single(EffectEngine.ActivateDelayedHealing(fight, 3));
+            Assert.Equal(expected, activated.Healed);
+            Assert.Equal(900 + expected, target.CurrentHP);
+            Assert.Empty(EffectEngine.ActivateDelayedHealing(fight, 3));
+        }
+
+        [Fact]
+        public void Healing_never_resurrects_a_dead_target()
+        {
+            var fight = new FightInstance(1, 1);
+            var caster = Fighter(1, 100, 1000, 1000);
+            var target = Fighter(2, 101, 0, 1000);
+            fight.AddPlayer(caster);
+            fight.AddPlayer(target);
+
+            var outcomes = EffectEngine.ResolveEffects(
+                fight, caster, 100, 1, target, EffectEngine.AlLanzar, 1,
+                new[]
+                {
+                    FixedHeal(100, 100),
+                    new SpellEffect
+                    {
+                        EffectId = EffectSupport.HealPercent,
+                        EffectUid = 4,
+                        DiceNum = 50,
+                        Triggers = EffectEngine.AlLanzar,
+                    },
+                });
+
+            Assert.Empty(outcomes);
+            Assert.Equal(0, target.CurrentHP);
+        }
+
+        private static Fighter Fighter(long id, int cell, int currentHp, int maxHp)
+            => new Fighter { Id = id, CellId = cell, CurrentHP = currentHp, MaxHP = maxHp };
+
+        private static SpellEffect FixedHeal(int diceMin, int diceMax, string targetMask = "")
+            => new SpellEffect
+            {
+                EffectId = EffectSupport.Heal,
+                EffectUid = 1,
+                DiceNum = diceMin,
+                DiceSide = diceMax,
+                Triggers = EffectEngine.AlLanzar,
+                TargetMask = targetMask,
+            };
+    }
+}

--- a/Jondo.Unity.World/Combat/EffectSupport.cs
+++ b/Jondo.Unity.World/Combat/EffectSupport.cs
@@ -26,17 +26,16 @@ namespace Jondo.Unity.World.Combat
     /// </summary>
     /// <remarks>
     /// This is the information the architecture document calls the most useful thing in the whole
-    /// spell module, and the reason is effect 108 — healing. Its catalogue row carries no
-    /// characteristic, so it falls through to the panel-only branch: the spell card says the spell
-    /// heals, the animation plays, and nobody's life goes up. Nothing anywhere says so, and until
-    /// now the only way to know was to read <c>EffectEngine.cs</c>.
+    /// spell module. Effect 108 — healing — is the reason this list matters: its catalogue row
+    /// carries no characteristic, so it used to fall through to the panel-only branch even though
+    /// the spell card said that it healed. Keeping it here makes the implementation explicit.
     ///
     /// There are two ways an effect can work, and they are not the same:
     ///
     /// <code>
     ///   Direct           the engine has code for it by name — a push, a summon, a state
     ///   Characteristic   its Effects row has Characteristic > 0, so the engine applies it
-    ///                    generically without knowing what it is. 213 of 872 are like this.
+    ///                    generically without knowing what it is. 205 of 872 are like this.
     ///   PanelOnly        neither. It is drawn on the card and does nothing at all.
     /// </code>
     ///
@@ -72,6 +71,9 @@ namespace Jondo.Unity.World.Combat
         /// <summary>Summon a creature.</summary>
         public const int Summon = 181;
 
+        /// <summary>Heal a fixed amount, scaled by Intelligence and the Heals characteristic.</summary>
+        public const int Heal = 108;
+
         /// <summary>Heal a percentage of maximum life.</summary>
         public const int HealPercent = 1109;
 
@@ -103,7 +105,7 @@ namespace Jondo.Unity.World.Combat
             {
                 Push, Pull, StepBack, StepForward,
                 AddState, RemoveState,
-                CastSpell, Summon, HealPercent, Kill,
+                CastSpell, Summon, Heal, HealPercent, Kill,
             };
 
             for (int damage = FirstDamage; damage <= LastDamage; damage++) known.Add(damage);

--- a/Jondo.Unity.World/Fights/Buff.cs
+++ b/Jondo.Unity.World/Fights/Buff.cs
@@ -72,6 +72,13 @@ namespace Jondo.Unity.World.Fights
         /// </summary>
         public bool Apila { get; set; }
 
+        /// <summary>
+        /// An instantaneous heal waiting for <see cref="EmpiezaEnRonda"/>. The amount is resolved
+        /// when the spell is cast, like every other delayed buff, but missing-life capping is done
+        /// only when the heal becomes due.
+        /// </summary>
+        public int PendingHealPoints { get; set; }
+
         public bool Vivo(int ronda)
             => ronda >= EmpiezaEnRonda && (CaducaEnRonda < 0 || ronda < CaducaEnRonda);
     }
@@ -183,6 +190,11 @@ namespace Jondo.Unity.World.Fights
             {
                 yaEstaba.Cuanto = embrujo.Cuanto;
                 yaEstaba.CaducaEnRonda = embrujo.CaducaEnRonda;
+                if (embrujo.PendingHealPoints > 0)
+                {
+                    yaEstaba.PendingHealPoints = embrujo.PendingHealPoints;
+                    yaEstaba.EmpiezaEnRonda = embrujo.EmpiezaEnRonda;
+                }
                 return yaEstaba;
             }
 
@@ -253,6 +265,18 @@ namespace Jondo.Unity.World.Fights
             var caidos = _puestos.FindAll(e => Caducado(e, ronda));
             _puestos.RemoveAll(e => Caducado(e, ronda));
             return caidos;
+        }
+
+        /// <summary>
+        /// Removes and returns delayed one-shot heals whose start round has arrived. They must be
+        /// taken before the regular expiry sweep because a zero-duration effect expires one round
+        /// after it starts.
+        /// </summary>
+        public List<Buff> TakeDueHealing(int round)
+        {
+            var due = _puestos.FindAll(e => e.PendingHealPoints > 0 && round >= e.EmpiezaEnRonda);
+            _puestos.RemoveAll(e => e.PendingHealPoints > 0 && round >= e.EmpiezaEnRonda);
+            return due;
         }
 
         /// <summary>Si a un embrujo se le ha pasado la hora. Uno que aun no ha empezado, NO.</summary>

--- a/README.md
+++ b/README.md
@@ -223,7 +223,7 @@ One engine for all eighteen classes, driven entirely by client data. Not a singl
 - ✅ Summons as real fighters — own sheet, place in the carousel next to their owner, behaviour spell, lifetime, and they all fall when their summoner dies
 - ✅ Item attitudes — the six Dofus and the trophies grant their spell through effect 1175
 - ✅ The characteristic sheet in the shape the client expects: 53 entries in a fixed order, and a single-characteristic refresh **replaces** its entry rather than adding to it, so it repeats every field and puts the buff in its own slot `f8`
-- ❌ Healing — effect 108 is not wired; its catalogue row has `Characteristic = 0` and `Category = 2`, so it falls into the panel-only branch
+- 🚧 Healing — fixed effect 108 works immediately and with spell delays; elemental fixed-heal variants are still pending
 - ❌ Glyphs and traps (effects 400, 401, 1091)
 - ❌ Appearance-changing spells — the transform payload is an opaque blob, so the Cra's Sentinel works but does not change its look
 - ❌ Area shapes `G` (55 effects) and `*` (10), which fall back to the centre tile alone
@@ -366,11 +366,11 @@ is wrong. Four things it found, all measured:
   across 401 captures, 184 shows up on 420 elements and 114 on 23, every one a zaap. Our own log
   catches us emitting the pair `(type 0, skill 114)` 84 times — a pair that occurs zero times
   anywhere real. New passages declare 184
-- **647 of the game's 872 effects do nothing at all.** They are drawn on the spell card and the
-  engine has no code for them and no characteristic to apply — and **15,841 of the 34,823 spell
+- **646 of the game's 872 effects do nothing at all.** They are drawn on the spell card and the
+  engine has no code for them and no characteristic to apply — and **15,348 of the 34,823 spell
   levels carry at least one**. The Studio ranks them by how many levels each one breaks, which turns
-  a curiosity into a work list: effect 1160 alone is on 6,709 levels, and healing — effect 108 — is
-  on 751
+  a curiosity into a work list: effect 1160 alone is on 6,709 levels. Healing — effect 108 — used
+  to be next on 751 levels and is now handled directly
 - **A monster's picture is filed under its `gfxId`, not its id.** Keyed by id, 847 of 5,134 found a
   picture and every one of those 847 was *somebody else's* creature. Keyed by gfxId it is 5,130
 
@@ -418,7 +418,7 @@ Full workings in **`docs/quests.md`** and **`docs/dungeons.md`**.
   right-click menu is drawn by the *client* from the template's `actions[]`, so an action written
   per placement can only take options away, never add one. Adding would need the map-load packet to
   carry actions per actor, and that has to be measured against a capture first
-- 🚧 **Editing spells.** The simulator is there; changing a spell's numbers is not — and with 647
+- 🚧 **Editing spells.** The simulator is there; changing a spell's numbers is not — and with 646
   effects doing nothing, implementing the top of that list buys far more than editing the values of
   an effect the engine ignores
 - 🚧 **Shops, loot tables and dungeons** — asked for by the people using it. All three are screens


### PR DESCRIPTION
## Resumen
- implementa la cura fija del efecto 108 dentro del recorrido real de efectos
- comparte una sola tirada base por zona y aplica después caída por distancia, Inteligencia, curas planas y el multiplicador recibido
- limita la cura a la vida que falta y nunca resucita a un objetivo muerto
- conserva el comportamiento existente de las curas porcentuales
- programa las curas con retraso como efectos de una sola activación y las consume en la ronda correcta
- anuncia la cura, la vida actualizada y la retirada del efecto con los constructores de protocolo que ya existen

## Alcance
No se introduce ninguna forma nueva de paquete. Las variantes elementales de cura fija quedan fuera de esta PR y el README mantiene la función en estado parcial.

## Pruebas
- `HealingTests` y `EffectSupportTests`: 24/24
- suite completa: 507/507
- validación manual en el cliente: la invocación curadora recupera vida y continúa su turno