### PR TITLE
Corregir los rebotes y la animacion de Flecha Fulminante

### DIFF
--- a/Jondo.Unity.Server/Handlers/FightHandler.cs
+++ b/Jondo.Unity.Server/Handlers/FightHandler.cs
@@ -2877,6 +2877,36 @@ namespace Jondo.Unity.Server.Handlers
 
             foreach (var c in consecuencias)
             {
+                if (c.NestedDamage)
+                {
+                    Fighter animationCaster = c.AnimationCaster ?? c.Caster ?? quienLanza;
+                    var animationGrade = LimitesDeGrado(c.HechizoOrigen, c.NivelOrigen);
+                    if (animationGrade.LevelId > 0)
+                    {
+                        await WriteFrameAsync(stream, ConnectionProtocol.Push(Op.Jwe,
+                            Network.FightProtocol.BuildAction(
+                                animationCaster.Id,
+                                Network.FightProtocol.Cast,
+                                Network.FightProtocol.CastAt(
+                                    animationCaster.Id, c.Sobre.Id, c.Sobre.CellId,
+                                    c.HechizoOrigen, animationGrade.LevelId,
+                                    c.CriticalDamage),
+                                Network.FightProtocol.CastDetail)));
+                        Program.LogDebug($"[Fight] Nested spell {c.HechizoOrigen} animation " +
+                                         $"{animationCaster.Id} -> {c.Sobre.Id} on cell " +
+                                         $"{c.Sobre.CellId} (level {animationGrade.LevelId}).");
+                    }
+
+                    int lifeBefore = c.Sobre.CurrentHP;
+                    await UnGolpeAsync(
+                        stream, fight, c.Caster ?? quienLanza, c.HechizoOrigen, c.Efecto,
+                        c.DamageElement, c.Sobre, TirarElDado(c.Efecto), c.DamageDistance,
+                        c.CriticalDamage, c.DamageSpellBonus);
+                    if (c.Sobre.IsAlive && c.Sobre.CurrentHP != lifeBefore)
+                        await RefrescarLaVidaAsync(stream, fight, c.Sobre);
+                    continue;
+                }
+
                 if (c.Caracteristica == ActionPointsCharacteristic)
                 {
                     // TRAZA para medir la retirada de PA. Se apunta de qué a qué, con qué efecto
@@ -3373,7 +3403,7 @@ namespace Jondo.Unity.Server.Handlers
                                                Fighter caster, int spell,
                                                Managers.SpellEffect efecto, int elemento,
                                                Fighter target, int sacadoDelDado, int lejosDelCentro,
-                                               bool critical)
+                                               bool critical, int? capturedSpellBonus = null)
         {
             // El elemento lo dice el catálogo: 0 neutral, 1 tierra, 2 fuego, 3 agua, 4 aire.
             var element = elemento switch
@@ -3402,7 +3432,8 @@ namespace Jondo.Unity.Server.Handlers
             // Y lo que le hayan sumado a ESE hechizo por embrujo: el efecto 293, "+#3 de daños
             // básicos". Flecha Helada se lo pone a sí misma, así que la segunda vez que se lanza
             // pega más que la primera.
-            int deEmbrujo = caster.Buffs.DelHechizo(spell, Jondo.Unity.World.Fights.SpellAspect.DanoBase, fight.RoundNumber);
+            int deEmbrujo = capturedSpellBonus ?? caster.Buffs.DelHechizo(
+                spell, Jondo.Unity.World.Fights.SpellAspect.DanoBase, fight.RoundNumber);
             if (deEmbrujo != 0)
             {
                 baseDamage += deEmbrujo;
@@ -4502,6 +4533,53 @@ namespace Jondo.Unity.Server.Handlers
 
             _grades[(spellId, nivel)] = salida;
             return salida;
+        }
+
+        /// <summary>Exact hidden-spell grade used by chained cast animations.</summary>
+        private static LimitesDelHechizo LimitesDeGrado(int spellId, int grade)
+        {
+            int exactGrade = Math.Max(1, grade);
+            var cacheKey = (spellId, -exactGrade);
+            if (_grades.TryGetValue(cacheKey, out var known)) return known;
+
+            var result = new LimitesDelHechizo(0, 0, exactGrade, 0, 0, 0, 0, 0);
+            try
+            {
+                using var connection = new Microsoft.Data.Sqlite.SqliteConnection(
+                    DatabaseManager.WorldConnectionString);
+                connection.Open();
+
+                var command = connection.CreateCommand();
+                command.CommandText =
+                    "SELECT APCost, Id, Grade, MaxCastPerTurn, MaxCastPerTarget, " +
+                    "MinCastInterval, InitialCooldown, CriticalHitProbability, " +
+                    "MinRange, MaxRange FROM SpellLevels " +
+                    "WHERE SpellId = $id AND Grade = $grade LIMIT 1;";
+                command.Parameters.AddWithValue("$id", spellId);
+                command.Parameters.AddWithValue("$grade", exactGrade);
+
+                using var reader = command.ExecuteReader();
+                if (reader.Read())
+                {
+                    result = new LimitesDelHechizo(
+                        (int)reader.GetInt64(0), (int)reader.GetInt64(1), (int)reader.GetInt64(2),
+                        reader.IsDBNull(3) ? 0 : (int)reader.GetInt64(3),
+                        reader.IsDBNull(4) ? 0 : (int)reader.GetInt64(4),
+                        reader.IsDBNull(5) ? 0 : (int)reader.GetInt64(5),
+                        reader.IsDBNull(6) ? 0 : (int)reader.GetInt64(6),
+                        reader.IsDBNull(7) ? 0 : (int)reader.GetInt64(7),
+                        reader.IsDBNull(8) ? 0 : (int)reader.GetInt64(8),
+                        reader.IsDBNull(9) ? 0 : (int)reader.GetInt64(9));
+                }
+            }
+            catch (Exception ex)
+            {
+                Program.LogDebug($"[Fight] Could not read exact grade {exactGrade} of spell " +
+                                 $"{spellId}: {ex.Message}");
+            }
+
+            _grades[cacheKey] = result;
+            return result;
         }
 
         /// <summary>

--- a/Jondo.Unity.Server/Managers/EffectEngine.cs
+++ b/Jondo.Unity.Server/Managers/EffectEngine.cs
@@ -1,6 +1,7 @@
 using Jondo.Unity.World.Combat;
 using System;
 using System.Collections.Generic;
+using System.Linq;
 using Jondo.Unity.World.Fights;
 
 namespace Jondo.Unity.Server.Managers
@@ -12,6 +13,14 @@ namespace Jondo.Unity.Server.Managers
     public sealed class Outcome
     {
         public Fighter Sobre { get; init; } = null!;
+        /// <summary>The concrete caster after following a hidden spell chain.</summary>
+        public Fighter Caster { get; init; }
+        /// <summary>
+        /// The fighter from whose cell a hidden chained spell is visually launched. Damage still
+        /// belongs to <see cref="Caster"/>; a nearest-target rebound merely travels from its
+        /// previous victim to the next one on the client.
+        /// </summary>
+        public Fighter AnimationCaster { get; init; }
         public SpellEffect Efecto { get; init; } = null!;
         public Buff Buff { get; init; }
         public int HechizoOrigen { get; init; }
@@ -24,6 +33,17 @@ namespace Jondo.Unity.Server.Managers
         /// <summary>Si el efecto encadena otro hechizo, cuál y en qué grado.</summary>
         public int HechizoEncadenado { get; init; }
         public int GradoEncadenado { get; init; }
+
+        /// <summary>
+        /// A concrete damage row selected inside a chained spell. Root-cast damage still follows
+        /// the ordinary damage pipeline; this marker preserves the target and spell-bonus
+        /// snapshot of a hidden 792/1160/2160 execution.
+        /// </summary>
+        public bool NestedDamage { get; init; }
+        public int DamageElement { get; init; }
+        public int DamageDistance { get; init; }
+        public int DamageSpellBonus { get; init; }
+        public bool CriticalDamage { get; init; }
 
         /// <summary>
         /// Si el efecto mueve a alguien, de dónde a dónde. Menos uno cuando no mueve a nadie.
@@ -253,6 +273,7 @@ namespace Jondo.Unity.Server.Managers
         /// Molosse/Apaisement aux sous-sorts qui ajoutent ou retirent la Rage.
         /// </summary>
         private const int DispararHechizo = EffectSupport.TriggerSpell;
+        private const int NearestTargetExecuteSpell = EffectSupport.NearestTargetExecuteSpell;
 
         private const int QuitarEfectosDeHechizo = EffectSupport.RemoveSpellEffects;
         private const int CambiarApariencia = EffectSupport.ChangeLook;
@@ -404,12 +425,18 @@ namespace Jondo.Unity.Server.Managers
         public static List<Outcome> Resolver(FightInstance combate, Fighter quienLanza,
                                                   int hechizo, int grado, Fighter objetivo,
                                                   string disparador, int ronda, int hondo = 0,
-                                                  int celdaApuntada = -1, bool critico = false)
+                                                  int celdaApuntada = -1, bool critico = false,
+                                                  int nearestChainBudget = -1,
+                                                  Fighter animationCaster = null)
         {
             if (hondo > HondoMaximo) return new List<Outcome>();
+            if (nearestChainBudget < 0)
+                nearestChainBudget = Todos(combate).Count(fighter => fighter != null && fighter.IsAlive);
             return ResolveEffects(combate, quienLanza, hechizo, grado, objetivo, disparador, ronda,
                                   EfectosDeLaTirada(hechizo, grado, critico), hondo,
-                                  celdaApuntada);
+                                  celdaApuntada, critical: critico,
+                                  nearestChainBudget: nearestChainBudget,
+                                  animationCaster: animationCaster);
         }
 
         /// <summary>
@@ -428,10 +455,14 @@ namespace Jondo.Unity.Server.Managers
         internal static List<Outcome> ResolveEffects(
             FightInstance combat, Fighter caster, int spell, int grade, Fighter target,
             string trigger, int round, IReadOnlyList<SpellEffect> effects, int depth = 0,
-            int aimedCell = -1, Func<SpellEffect, int> rollEffect = null)
+            int aimedCell = -1, Func<SpellEffect, int> rollEffect = null,
+            bool critical = false, int nearestChainBudget = -1,
+            Fighter animationCaster = null)
         {
             var fuera = new List<Outcome>();
             if (depth > HondoMaximo) return fuera;
+            if (nearestChainBudget < 0)
+                nearestChainBudget = Todos(combat).Count(fighter => fighter != null && fighter.IsAlive);
 
             // Every state condition of one spell is judged against the SAME snapshot, and Rage is
             // why that matters: grade 1 of spell 13745 carries all three branches -- 0->I, I->II
@@ -460,6 +491,40 @@ namespace Jondo.Unity.Server.Managers
                 }
                 if (!leToca) continue;
 
+                // Root damage is sent by HurtAsync. Damage inside a hidden chained spell must be
+                // materialized here or Aplicar will deliberately discard it as an ordinary row.
+                if (depth > 0 && EsDeDano(efecto.EffectId))
+                {
+                    int element = efecto.Element >= 0
+                        ? efecto.Element
+                        : DatabaseManager.EffectElement(efecto.EffectId);
+                    int spellBonus = caster.Buffs.DelHechizo(
+                        spell, SpellAspect.DanoBase, round);
+                    foreach (var recipient in AQuien(
+                                 combat, caster, target, efecto, aimedCell, estadosAlEmpezar))
+                    {
+                        if (recipient == null || !recipient.IsAlive) continue;
+                        fuera.Add(new Outcome
+                        {
+                            Sobre = recipient,
+                            Caster = caster,
+                            AnimationCaster = animationCaster ?? caster,
+                            Efecto = efecto,
+                            HechizoOrigen = spell,
+                            NivelOrigen = grade,
+                            NestedDamage = true,
+                            DamageElement = element,
+                            DamageDistance = aimedCell >= 0
+                                ? Jondo.Unity.World.Maps.MapGeometry.Distance(
+                                    aimedCell, recipient.CellId)
+                                : 0,
+                            DamageSpellBonus = spellBonus,
+                            CriticalDamage = critical,
+                        });
+                    }
+                    continue;
+                }
+
                 // Fixed healing follows damage's roll semantics: one effect roll is shared by all
                 // recipients in the zone, then each recipient gets its own distance falloff.
                 int sharedHealRoll = efecto.EffectId == FixedHeal
@@ -479,6 +544,40 @@ namespace Jondo.Unity.Server.Managers
                     var puesta = Aplicar(combat, caster, caster, spell, grade, efecto,
                                          round, aimedCell, sharedHealRoll);
                     if (puesta != null) fuera.Add(puesta);
+                    continue;
+                }
+
+                // Effect 2160 executes one spell on the nearest eligible target. This selection
+                // intentionally uses live states: the same hidden spell has just marked its
+                // current victim, and that mark is the loop guard for the next rebound.
+                if (efecto.EffectId == NearestTargetExecuteSpell)
+                {
+                    if (nearestChainBudget <= 0) continue;
+                    Fighter nearest = AQuien(combat, caster, target, efecto, aimedCell)
+                        .Where(candidate => candidate != null && candidate.IsAlive)
+                        .OrderBy(candidate => aimedCell >= 0
+                            ? Jondo.Unity.World.Maps.MapGeometry.Distance(
+                                aimedCell, candidate.CellId)
+                            : 0)
+                        .ThenBy(candidate => candidate.CellId)
+                        .ThenBy(candidate => candidate.Id)
+                        .FirstOrDefault();
+                    if (nearest == null) continue;
+
+                    var chained = Aplicar(combat, caster, nearest, spell, grade, efecto, round,
+                                          nearest.CellId, sharedHealRoll);
+                    if (chained == null) continue;
+                    fuera.Add(chained);
+                    if (chained.HechizoEncadenado != 0)
+                    {
+                        fuera.AddRange(Resolver(
+                            combat, caster, chained.HechizoEncadenado,
+                            chained.GradoEncadenado, nearest, AlLanzar, round,
+                            depth, nearest.CellId, critical, nearestChainBudget - 1,
+                            // Keep damage attribution on the Cra while drawing the next spell
+                            // from the previous victim's cell.
+                            target));
+                    }
                     continue;
                 }
 
@@ -506,7 +605,8 @@ namespace Jondo.Unity.Server.Managers
                     {
                         fuera.AddRange(Resolver(combat, caster, hecho.HechizoEncadenado,
                                                 hecho.GradoEncadenado, sobre, AlLanzar, round,
-                                                depth + 1, aimedCell));
+                                                depth + 1, aimedCell, critical,
+                                                nearestChainBudget));
                     }
                 }
             }
@@ -533,6 +633,7 @@ namespace Jondo.Unity.Server.Managers
             bool alLanzador = false, aLosMios = false, aLosDeEnfrente = false, aLasInvocaciones = false;
             var pideEstado = new List<int>();
             var pideNoEstado = new List<int>();
+            var requiredMonsterTemplates = new List<int>();
 
             foreach (var trozo in mascara.Split(','))
             {
@@ -555,6 +656,15 @@ namespace Jondo.Unity.Server.Managers
                 // Las invocaciones. Son 1.518 efectos en la base con "g" a secas, y hasta ahora se
                 // caían todos en silencio: es lo que dejaba a la Baliza de Supervivencia sin curar.
                 if (t == "g") { aLasInvocaciones = true; continue; }
+
+                // Multiple uppercase F entries are alternatives. Fulminating Arrow uses this to
+                // mark either Cra beacon template while excluding ordinary allies.
+                if (t.Length > 1 && t[0] == 'F' &&
+                    int.TryParse(t.Substring(1), out int monsterTemplate))
+                {
+                    requiredMonsterTemplates.Add(monsterTemplate);
+                    continue;
+                }
 
                 if (t.Length > 1 && (t[0] == 'e' || t[0] == 'E') && int.TryParse(t.Substring(1), out int estado))
                 {
@@ -610,6 +720,11 @@ namespace Jondo.Unity.Server.Managers
                     ? alEntrar
                     : quien.Buffs.Estados as IReadOnlySet<int> ?? new HashSet<int>(quien.Buffs.Estados);
                 bool vale = true;
+                if (requiredMonsterTemplates.Count > 0 &&
+                    (!quien.IsMonster || !requiredMonsterTemplates.Contains(quien.MonsterId)))
+                {
+                    vale = false;
+                }
                 foreach (int estado in pideEstado) if (!susEstados.Contains(estado)) vale = false;
                 foreach (int estado in pideNoEstado) if (susEstados.Contains(estado)) vale = false;
                 if (vale) yield return quien;
@@ -802,7 +917,8 @@ namespace Jondo.Unity.Server.Managers
                 };
             }
 
-            if (efecto.EffectId == LanzarHechizo || efecto.EffectId == DispararHechizo)
+            if (efecto.EffectId == LanzarHechizo || efecto.EffectId == DispararHechizo ||
+                efecto.EffectId == NearestTargetExecuteSpell)
             {
                 // "Lanza el hechizo del dado en el grado de la cara". Es el enganche de las
                 // actitudes: el grado 1 del Amarillo Ocre no hace nada por sí mismo, sólo dice
@@ -910,6 +1026,8 @@ namespace Jondo.Unity.Server.Managers
                     Sobre = que,
                     HechizoAfectado = efecto.DiceNum,
                     Cuanto = cuanto,
+                    Apila = efecto.MaxStack > 1,
+                    MaxStacks = Math.Max(0, efecto.MaxStack),
                     HechizoOrigen = hechizo,
                     NivelOrigen = grado,
                     Quien = quienLanza.Id,

--- a/Jondo.Unity.Server/Managers/SpellEffects.cs
+++ b/Jondo.Unity.Server/Managers/SpellEffects.cs
@@ -74,6 +74,12 @@ namespace Jondo.Unity.Server.Managers
         public int TopeDeCaida { get; init; }
 
         /// <summary>
+        /// Maximum number of identical rows the spell level allows to coexist. Values at or below
+        /// one use refresh semantics; a larger value is a real stack limit.
+        /// </summary>
+        public int MaxStack { get; init; }
+
+        /// <summary>
         /// La probabilidad de que a este efecto le toque, en tanto por ciento, y el sorteo al que
         /// pertenece.
         ///
@@ -135,7 +141,7 @@ namespace Jondo.Unity.Server.Managers
 
                     var orden = conexion.CreateCommand();
                     orden.CommandText =
-                        "SELECT EffectsJson, CriticalEffectsJson FROM SpellLevels " +
+                        "SELECT EffectsJson, CriticalEffectsJson, MaxStack FROM SpellLevels " +
                         "WHERE SpellId = $id AND Grade = $g LIMIT 1;";
                     orden.Parameters.AddWithValue("$id", hechizo);
                     orden.Parameters.AddWithValue("$g", clave.Item2);
@@ -143,8 +149,9 @@ namespace Jondo.Unity.Server.Managers
                     using var lector = orden.ExecuteReader();
                     if (lector.Read())
                     {
-                        Parsear(lector.IsDBNull(0) ? "" : lector.GetString(0), normales);
-                        Parsear(lector.IsDBNull(1) ? "" : lector.GetString(1), criticos);
+                        int maxStack = lector.IsDBNull(2) ? -1 : lector.GetInt32(2);
+                        Parsear(lector.IsDBNull(0) ? "" : lector.GetString(0), normales, maxStack);
+                        Parsear(lector.IsDBNull(1) ? "" : lector.GetString(1), criticos, maxStack);
                     }
                 }
                 catch (Exception ex)
@@ -159,7 +166,7 @@ namespace Jondo.Unity.Server.Managers
             }
         }
 
-        private static void Parsear(string json, List<SpellEffect> donde)
+        private static void Parsear(string json, List<SpellEffect> donde, int maxStack)
         {
             if (string.IsNullOrEmpty(json)) return;
             try
@@ -199,6 +206,7 @@ namespace Jondo.Unity.Server.Managers
                         ParaEnElObjetivo = para,
                         PasoDeCaida = paso,
                         TopeDeCaida = tope,
+                        MaxStack = maxStack,
                         Probabilidad = e.TryGetProperty("random", out var rnd) &&
                                        rnd.TryGetDouble(out double p) ? p : 0,
                         Sorteo = Entero(e, "group"),

--- a/Jondo.Unity.Tests/Combat/CraFulminatingArrowTests.cs
+++ b/Jondo.Unity.Tests/Combat/CraFulminatingArrowTests.cs
@@ -1,0 +1,145 @@
+using System.Collections.Generic;
+using System.Linq;
+using Jondo.Unity.Server.Managers;
+using Jondo.Unity.World.Combat;
+using Jondo.Unity.World.Fights;
+using Jondo.Unity.World.Maps;
+using Xunit;
+
+namespace Jondo.Unity.Tests.Combat
+{
+    public class CraFulminatingArrowTests
+    {
+        private const int FulminatingArrow = 32450;
+        private const int ReboundSpell = 32452;
+
+        [Fact]
+        public void Current_catalogue_uses_nearest_target_execution_for_the_rebound()
+        {
+            var rebound = Assert.Single(SpellEffects.De(ReboundSpell, 1),
+                effect => effect.EffectId == EffectSupport.NearestTargetExecuteSpell);
+
+            Assert.Equal(ReboundSpell, rebound.DiceNum);
+            Assert.Equal(1, rebound.DiceSide);
+            Assert.Equal(2, rebound.Tamano);
+            Assert.Contains("E3551", rebound.TargetMask);
+            Assert.Contains("e570", rebound.TargetMask);
+            Assert.Contains(EffectSupport.NearestTargetExecuteSpell,
+                            EffectSupport.HandledDirectly);
+        }
+
+        [Fact]
+        public void Fulminating_arrow_hits_a_nearest_chain_and_caps_its_bonus()
+        {
+            var fight = new FightInstance(1, 1);
+            var cra = Alive(1, team: 0, cell: 300);
+            var cells = ConnectedCells(origin: 100, count: 7);
+            var enemies = cells.Select((cell, index) => Alive(-index - 1, 1, cell)).ToList();
+            fight.AddPlayer(cra);
+            foreach (var enemy in enemies) fight.AddMonster(enemy);
+
+            var outcomes = EffectEngine.Resolver(
+                fight, cra, FulminatingArrow, 1, enemies[0], EffectEngine.AlLanzar,
+                fight.RoundNumber, celdaApuntada: enemies[0].CellId);
+            var damage = outcomes.Where(outcome => outcome.NestedDamage).ToList();
+
+            Assert.Equal(7, damage.Count);
+            Assert.Equal(enemies[0], damage[0].Sobre);
+            Assert.Equal(new[] { 0, 15, 30, 45, 60, 60, 60 },
+                         damage.Select(outcome => outcome.DamageSpellBonus));
+            Assert.All(damage, outcome =>
+            {
+                Assert.Equal(ReboundSpell, outcome.HechizoOrigen);
+                Assert.Equal(2, outcome.DamageElement);
+                Assert.False(outcome.CriticalDamage);
+            });
+            Assert.Equal(7, damage.Select(outcome => outcome.Sobre.Id).Distinct().Count());
+            Assert.Equal(cra, damage[0].AnimationCaster);
+            Assert.Equal(enemies.Take(6),
+                         damage.Skip(1).Select(outcome => outcome.AnimationCaster));
+            Assert.All(enemies, enemy =>
+            {
+                Assert.False(enemy.Buffs.TieneEstado(3551));
+                Assert.False(enemy.Buffs.TieneEstado(570));
+            });
+            Assert.Equal(0, cra.Buffs.DelHechizo(
+                ReboundSpell, SpellAspect.DanoBase, fight.RoundNumber));
+        }
+
+        [Fact]
+        public void Fulminating_arrow_can_rebound_through_a_cra_beacon_but_not_an_ally()
+        {
+            var fight = new FightInstance(1, 1);
+            var cra = Alive(1, team: 0, cell: 300);
+            var target = Alive(-1, team: 1, cell: 100);
+            int adjacent = FirstCellAtDistance(target.CellId, 1, new HashSet<int>());
+            int otherAdjacent = FirstCellAtDistance(
+                target.CellId, 1, new HashSet<int> { adjacent });
+            var beacon = Alive(-2, team: 0, cell: adjacent);
+            beacon.IsMonster = true;
+            beacon.MonsterId = 8348;
+            beacon.Invocador = cra.Id;
+            var ally = Alive(2, team: 0, cell: otherAdjacent);
+            fight.AddPlayer(cra);
+            fight.AddPlayer(ally);
+            fight.AddMonster(target);
+            fight.AddMonster(beacon);
+
+            var damage = EffectEngine.Resolver(
+                    fight, cra, FulminatingArrow, 1, target, EffectEngine.AlLanzar,
+                    fight.RoundNumber, celdaApuntada: target.CellId)
+                .Where(outcome => outcome.NestedDamage)
+                .Select(outcome => outcome.Sobre)
+                .ToList();
+
+            Assert.Contains(target, damage);
+            Assert.Contains(beacon, damage);
+            Assert.DoesNotContain(ally, damage);
+        }
+
+        [Fact]
+        public void Critical_fulminating_arrow_uses_the_critical_rebound_row()
+        {
+            var fight = new FightInstance(1, 1);
+            var cra = Alive(1, team: 0, cell: 300);
+            var target = Alive(-1, team: 1, cell: 100);
+            fight.AddPlayer(cra);
+            fight.AddMonster(target);
+
+            var damage = Assert.Single(EffectEngine.Resolver(
+                    fight, cra, FulminatingArrow, 1, target, EffectEngine.AlLanzar,
+                    fight.RoundNumber, celdaApuntada: target.CellId, critico: true),
+                outcome => outcome.NestedDamage);
+
+            Assert.True(damage.CriticalDamage);
+            Assert.Equal(31, damage.Efecto.DiceNum);
+            Assert.Equal(35, damage.Efecto.DiceSide);
+        }
+
+        private static List<int> ConnectedCells(int origin, int count)
+        {
+            var cells = new List<int> { origin };
+            while (cells.Count < count)
+            {
+                int next = FirstCellAtDistance(cells[^1], 1, cells.ToHashSet());
+                cells.Add(next);
+            }
+            return cells;
+        }
+
+        private static int FirstCellAtDistance(int origin, int distance, HashSet<int> excluded)
+            => Enumerable.Range(0, MapGeometry.MaxCells)
+                .First(cell => !excluded.Contains(cell) &&
+                               MapGeometry.Distance(origin, cell) == distance);
+
+        private static Fighter Alive(long id, int team, int cell)
+            => new Fighter
+            {
+                Id = id,
+                TeamId = team,
+                CellId = cell,
+                MaxHP = 1000,
+                CurrentHP = 1000,
+            };
+    }
+}

--- a/Jondo.Unity.Tests/Combat/EffectSupportTests.cs
+++ b/Jondo.Unity.Tests/Combat/EffectSupportTests.cs
@@ -44,6 +44,7 @@ namespace Jondo.Unity.Tests.Combat
         [InlineData(EffectSupport.RemoveState)]
         [InlineData(EffectSupport.CastSpell)]
         [InlineData(EffectSupport.TriggerSpell)]
+        [InlineData(EffectSupport.NearestTargetExecuteSpell)]
         [InlineData(EffectSupport.RemoveSpellEffects)]
         [InlineData(EffectSupport.ChangeLook)]
         [InlineData(EffectSupport.Summon)]

--- a/Jondo.Unity.World/Combat/EffectSupport.cs
+++ b/Jondo.Unity.World/Combat/EffectSupport.cs
@@ -74,6 +74,12 @@ namespace Jondo.Unity.World.Combat
         /// </summary>
         public const int TriggerSpell = 1160;
 
+        /// <summary>
+        /// Execute the spell carried in DiceNum on the nearest eligible fighter in the effect
+        /// area. Chained spells use states to exclude fighters already visited by the chain.
+        /// </summary>
+        public const int NearestTargetExecuteSpell = 2160;
+
         /// <summary>Remove every buff left by one spell.</summary>
         public const int RemoveSpellEffects = 406;
 
@@ -137,7 +143,8 @@ namespace Jondo.Unity.World.Combat
             {
                 Push, Pull, StepBack, StepForward,
                 AddState, RemoveState,
-                CastSpell, TriggerSpell, RemoveSpellEffects, ChangeLook,
+                CastSpell, TriggerSpell, NearestTargetExecuteSpell,
+                RemoveSpellEffects, ChangeLook,
                 Summon, FireHeal, HealPercent, Kill,
             };
 

--- a/Jondo.Unity.World/Fights/Buff.cs
+++ b/Jondo.Unity.World/Fights/Buff.cs
@@ -75,6 +75,9 @@ namespace Jondo.Unity.World.Fights
         /// </summary>
         public bool Apila { get; set; }
 
+        /// <summary>Maximum equivalent rows that may coexist; zero means no explicit cap.</summary>
+        public int MaxStacks { get; set; }
+
         /// <summary>
         /// An instantaneous heal waiting for <see cref="EmpiezaEnRonda"/>. The amount is resolved
         /// when the spell is cast, like every other delayed buff, but missing-life capping is done
@@ -199,6 +202,22 @@ namespace Jondo.Unity.World.Fights
             // embrujo NUEVO por cada paso, apuntando al primero.
             if (embrujo.Apila)
             {
+                if (embrujo.MaxStacks > 0)
+                {
+                    var equivalent = _puestos.Where(e => e.EffectId == embrujo.EffectId
+                                                      && e.EffectUid == embrujo.EffectUid
+                                                      && e.HechizoOrigen == embrujo.HechizoOrigen
+                                                      && e.HechizoAfectado == embrujo.HechizoAfectado
+                                                      && e.Quien == embrujo.Quien).ToList();
+                    if (equivalent.Count >= embrujo.MaxStacks)
+                    {
+                        var oldest = equivalent[0];
+                        oldest.Cuanto = embrujo.Cuanto;
+                        oldest.CaducaEnRonda = embrujo.CaducaEnRonda;
+                        oldest.EmpiezaEnRonda = embrujo.EmpiezaEnRonda;
+                        return oldest;
+                    }
+                }
                 embrujo.Numero = siguienteNumero();
                 _puestos.Add(embrujo);
                 return embrujo;

--- a/Jondo.Unity.World/Maps/Zone.cs
+++ b/Jondo.Unity.World/Maps/Zone.cs
@@ -34,6 +34,7 @@ namespace Jondo.Unity.World.Maps
         public const int Aspa = 'X';
         public const int Cruz = 'T';
         public const int TodoElMapa = 'a';
+        public const int WholeMap = 'A';
         public const int Linea = 'L';
         public const int MediaLinea = 'V';
         public const int Rombo = 'Q';
@@ -59,6 +60,7 @@ namespace Jondo.Unity.World.Maps
                     return fuera;
 
                 case TodoElMapa:
+                case WholeMap:
                     for (int c = 0; c < MapGeometry.MaxCells; c++) fuera.Add(c);
                     return fuera;
 


### PR DESCRIPTION
## Resumen
- implementa el efecto 2160 seleccionando un unico objetivo elegible mas cercano en cada rebote
- conserva el lanzador real para el calculo de danos y usa la victima anterior como origen visual
- respeta los estados de visitado, las balizas de Ocra y el limite `MaxStack` de +60 danos base
- envia al cliente el lanzamiento del subhechizo 32452 antes de cada impacto

## Pruebas
- `dotnet test Jondo.Unity.Tests/Jondo.Unity.Tests.csproj -c Release --no-restore --nologo`
- 729 superadas, 0 fallidas
- prueba dedicada con siete objetivos, critico, baliza, aliado excluido, tope de acumulacion y origen visual

No incluye binarios ni otras correcciones del VPS.